### PR TITLE
[cmake] Keep a consistent PROJECT_NAME and name of the package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(AddWarningsConfigurationToTargets)
 include(CMakePackageConfigHelpers)
 
 
-project(unicyclePlanner CXX)
+project(UnicyclePlanner CXX)
 
 option(ENABLE_RPATH "Enable RPATH for this library" ON)
 mark_as_advanced(ENABLE_RPATH)


### PR DESCRIPTION
It is a good practice to reduce the naming madness of CMake.
Furthermore, in ensure that the default installation path in Windows is automatically found. 
See https://gitlab.kitware.com/cmake/cmake/issues/16212