### PR TITLE
Fix DCM trajectory generation of the last double support phase

### DIFF
--- a/include/DCMTrajectoryGeneratorHelper.h
+++ b/include/DCMTrajectoryGeneratorHelper.h
@@ -118,14 +118,18 @@ class DCMTrajectoryGeneratorHelper
      * @param ZMP contains the position of the ZMP at the beginning of the single support phase,
      * it is assumed coincedent with the center of the reference foot;
      * @param singleSupportBoundaryCondition contains the boundary position and time
-     * of the single support trajectory.
+     * of the single support trajectory;
+     * @param doubleSupportEndPosition contains the final position at the end of the
+     * double support phase.
      * @return true / false in case of success / failure.
      */
     bool addLastStep(const double &singleSupportStartTime,
                      const double &singleSupportEndTime,
                      const double &doubleSupportEndTime,
                      const iDynTree::Vector2 &ZMP,
-                     const DCMTrajectoryPoint& singleSupportBoundaryCondition);
+                     const DCMTrajectoryPoint& singleSupportBoundaryCondition,
+                     const iDynTree::Vector2 &doubleSupportEndPosition);
+
 
     /**
      * Add the Single and Double support phases for a general step.


### PR DESCRIPTION
This PR fixes the bug described in #25.  
In details:
1. the DCM position at the end of the last SS phase is now equal to the ZMP position
2. the initial velocity of the last double support trajectory is now evaluated by using the last single support trajectory. 

| With this PR| Without this PR |
|:----------------:|:---------------:|
|  ![dcm_fixed](https://user-images.githubusercontent.com/16744101/62255543-ea450380-b3fd-11e9-9b1d-d543b33e7706.png) |  ![dcm_bug](https://user-images.githubusercontent.com/16744101/62255550-f204a800-b3fd-11e9-8416-0170587d47e1.png) |

@prashanthr05 @MiladShafiee @lia2790