### PR TITLE
Add the possibility to retrieve the desired ZMP position when the DCM planner is used 

### DIFF
--- a/include/DCMTrajectoryGenerator.h
+++ b/include/DCMTrajectoryGenerator.h
@@ -83,6 +83,13 @@ public:
     const std::vector<iDynTree::Vector2>& getDCMVelocity() const;
 
     /**
+     * Get the position of the ZMP along the entire trajectory.
+     * @return a vector containing the position of the ZMP
+     */
+    const std::vector<iDynTree::Vector2>& getZMPPosition() const;
+
+
+    /**
      * Output the weight percentage carried by each foot while walking, according to the DCM trajectory.
      */
     void getWeightPercentage(std::vector<double>& weightInLeft, std::vector<double>& weightInRight) const;

--- a/src/DCMTrajectoryGenerator.cpp
+++ b/src/DCMTrajectoryGenerator.cpp
@@ -156,6 +156,13 @@ const std::vector<iDynTree::Vector2> &DCMTrajectoryGenerator::getDCMVelocity() c
     return m_pimpl->helper.getDCMVelocity();
 }
 
+
+const std::vector<iDynTree::Vector2> &DCMTrajectoryGenerator::getZMPPosition() const
+{
+    std::lock_guard<std::mutex> guard(m_pimpl->mutex);
+    return m_pimpl->helper.getZMPPosition();
+}
+
 void DCMTrajectoryGenerator::getWeightPercentage(std::vector<double> &weightInLeft, std::vector<double> &weightInRight) const
 {
     std::lock_guard<std::mutex> guard(m_pimpl->mutex);


### PR DESCRIPTION
With this PR it is possible to get the desired position of the ZMP if the DCM planner is used 