### PR TITLE
Introduce the lastStepDCMOffset parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include(CMakePackageConfigHelpers)
 
 project(UnicyclePlanner
         LANGUAGES CXX
-        VERSION 0.1.102)
+        VERSION 0.1.103)
 
 option(ENABLE_RPATH "Enable RPATH for this library" ON)
 mark_as_advanced(ENABLE_RPATH)

--- a/include/DCMTrajectoryGenerator.h
+++ b/include/DCMTrajectoryGenerator.h
@@ -63,6 +63,16 @@ public:
     bool setOmega(const double &omega);
 
     /**
+     * Set the last step DCM offset
+     * @param lastStepDCMOffset Number from 0 to 1 used to indicate the position of the DCM w.r.t. the last ZMP position.
+     * If it is 0.5 the final DCM will be in the middle of the two footsteps;
+     * If it is 0 the DCM position coincides with the stance foot ZMP;
+     * If it is 1 the DCM position coincides with the next foot ZMP position.
+     * @return true / false in case of success / failure.
+     */
+    bool setLastStepDCMOffsetPercentage(const double &lastStepDCMOffset);
+
+    /**
      * @brief Specifies an offset from the origin of the foot frame to be used when generating trajectories
      * @param offsetInLeftFootFrame Offset with respect the origin of the left foot
      * @param offsetInRightFootFrame Offset with respect the origin of the right foot

--- a/include/DCMTrajectoryGeneratorHelper.h
+++ b/include/DCMTrajectoryGeneratorHelper.h
@@ -97,6 +97,15 @@ class DCMTrajectoryGeneratorHelper
     iDynTree::Vector2 m_leftZMPDelta; /**< Vector containing the desired left ZMP delta. */
     iDynTree::Vector2 m_rightZMPDelta; /**< Vector containing the desired left ZMP delta. */
 
+    /**
+     * Number from 0 to 1 used to indicate the position of the DCM w.r.t. the last zmp position.
+     * If it is 0.5 the final DCM will be in the middle of the two footsteps;
+     * If it is 0 the DCM position coincides with the stance foot ZMP;
+     * If it is 1 the DCM position coincides with the next foot ZMP position.
+     * The default value is 0.
+     */
+    double m_lastStepDCMOffset;
+
     double m_maxDoubleSupportDuration; /**< Max duration of a DS phase. */
     double m_nominalDoubleSupportDuration; /**< Nominal duration of a DS phase. */
     bool m_pauseActive; /**< True if the pause feature is activate. */
@@ -222,6 +231,16 @@ class DCMTrajectoryGeneratorHelper
      * @return true if the pause conditions are set, false otherwise.
      */
     bool setPauseConditions(bool pauseActive, const double &maxDoubleSupportDuration, const double &nominalDoubleSupportDuration);
+
+    /**
+     * Set the last step DCM offset
+     * @param lastStepDCMOffset Number from 0 to 1 used to indicate the position of the DCM w.r.t. the last ZMP position.
+     * If it is 0.5 the final DCM will be in the middle of the two footsteps;
+     * If it is 0 the DCM position coincides with the stance foot ZMP;
+     * If it is 1 the DCM position coincides with the next foot ZMP position.
+     * @return true / false in case of success / failure.
+     */
+    bool setLastStepDCMOffsetPercentage(const double &lastStepDCMOffset);
 
     /**
      * Generate the Divergent Component of Motion trajectory.

--- a/src/DCMTrajectoryGenerator.cpp
+++ b/src/DCMTrajectoryGenerator.cpp
@@ -135,6 +135,13 @@ bool DCMTrajectoryGenerator::setOmega(const double &omega)
     return m_pimpl->helper.setOmega(omega);
 }
 
+bool DCMTrajectoryGenerator::setLastStepDCMOffsetPercentage(const double &lastStepDCMOffset)
+{
+    std::lock_guard<std::mutex> guard(m_pimpl->mutex);
+
+    return m_pimpl->helper.setLastStepDCMOffsetPercentage(lastStepDCMOffset);
+}
+
 bool DCMTrajectoryGenerator::setFootOriginOffset(const iDynTree::Vector2 &offsetInLeftFootFrame, const iDynTree::Vector2 &offsetInRightFootFrame)
 {
     std::lock_guard<std::mutex> guard(m_pimpl->mutex);

--- a/tests/DcmInterpolationTest.cpp
+++ b/tests/DcmInterpolationTest.cpp
@@ -60,6 +60,9 @@ typedef struct
     double lStancePositionX = 0.0, lStancePositionY = 0.0;
     double lSwitchInitPositionX = 0.0, lSwitchInitPositionY = 0.0;
 
+    // DCM offset percentage for the last step
+    double lastStepDCMOffsetPercentage = 0.2;
+
     bool swingLeft = true;
 } Configuration;
 
@@ -111,6 +114,7 @@ bool configureGenerator(UnicycleGenerator& generator, const Configuration &conf)
     rightOffset(0) = conf.rStancePositionX;
     rightOffset(1) = conf.rStancePositionY;
     iDynTree::assertTrue(dcmGenerator->setFootOriginOffset(leftOffset, rightOffset));
+    iDynTree::assertTrue(dcmGenerator->setLastStepDCMOffsetPercentage(conf.lastStepDCMOffsetPercentage));
 
     return ok;
 }

--- a/tests/DcmInterpolationTest.cpp
+++ b/tests/DcmInterpolationTest.cpp
@@ -104,7 +104,7 @@ bool configureGenerator(UnicycleGenerator& generator, const Configuration &conf)
     auto dcmGenerator = generator.addDCMTrajectoryGenerator();
 
     // Setup the dcm planner
-    iDynTree::assertTrue(dcmGenerator->setOmega(9.81/conf.comHeight));
+    iDynTree::assertTrue(dcmGenerator->setOmega(std::sqrt(9.81/conf.comHeight)));
     iDynTree::Vector2 leftOffset, rightOffset;
     leftOffset(0) = conf.lStancePositionX;
     leftOffset(1) = conf.lStancePositionY;

--- a/tests/DcmInterpolationTest.cpp
+++ b/tests/DcmInterpolationTest.cpp
@@ -119,19 +119,20 @@ bool configureGenerator(UnicycleGenerator& generator, const Configuration &conf)
  * Save all the trajectories in files
  */
 void printTrajectories(UnicycleGenerator& generator, size_t& newMergePoint, size_t mergePoint, DCMInitialState& boundaryConditionAtMergePoint,
-                       const std::string& DCMPosFileName, const std::string& DCMVelFileName,
+                       const std::string& DCMPosFileName, const std::string& DCMVelFileName, const std::string& ZMPPosFileName,
                        const std::string& mergePointFileName,
                        const std::string& lFootWeightFileName, const std::string& rFootWeightFileName)
 {
     auto dcmGenerator = generator.addDCMTrajectoryGenerator();
 
     // instantiate ofstream
-    std::ofstream DCMPosStream, DCMVelStream;
+    std::ofstream DCMPosStream, DCMVelStream, ZMPPosStream;
     std::ofstream mergePointsStream;
     std::ofstream lFootWeightStream, rFootWeightStream;
 
 
     DCMPosStream.open(DCMPosFileName.c_str());
+    ZMPPosStream.open(ZMPPosFileName.c_str());
     DCMVelStream.open(DCMVelFileName.c_str());
 
     mergePointsStream.open(mergePointFileName.c_str());
@@ -170,6 +171,16 @@ void printTrajectories(UnicycleGenerator& generator, size_t& newMergePoint, size
     DCMVelStream << "DCM_vx DCM_vy" <<std::endl;
     print_iDynTree(DCMVelVector, DCMVelStream);
 
+
+    // print the position of the ZMP
+    static std::vector<iDynTree::Vector2> ZMPPosVector;
+    std::vector<iDynTree::Vector2> ZMPPosInput;
+    ZMPPosInput = dcmGenerator->getZMPPosition();
+    ZMPPosVector.insert(ZMPPosVector.begin() + mergePoint, ZMPPosInput.begin(), ZMPPosInput.end());
+    ZMPPosVector.resize(mergePoint + ZMPPosInput.size());
+    ZMPPosStream << "ZMP_x ZMP_y" <<std::endl;
+    print_iDynTree(ZMPPosVector, ZMPPosStream);
+
     static std::vector < double > lFootWeight;
     std::vector < double > lFootWeightIn;
     static std::vector < double > rFootWeight;
@@ -193,6 +204,7 @@ void printTrajectories(UnicycleGenerator& generator, size_t& newMergePoint, size
 
     DCMPosStream.close();
     DCMVelStream.close();
+    ZMPPosStream.close();
 
     mergePointsStream.close();
 
@@ -261,6 +273,7 @@ bool interpolationTest()
     std::string heightAccFileName("heightAcc1.txt");
     std::string DCMPosFileName("DCMPos1.txt");
     std::string DCMVelFileName("DCMVel1.txt");
+    std::string ZMPPosFileName("ZMPPos1.txt");
     std::string mergePointsFileName("mergePoints1.txt");
     std::string lFootWeightFileName("leftFootWeight1.txt");
     std::string rFootWeightFileName("rightFootWeight1.txt");
@@ -272,7 +285,7 @@ bool interpolationTest()
     // print the trajectory in the files
     DCMInitialState boundaryConditionAtMergePoint;
     printTrajectories(unicycleGenerator, newMergePoint, 0, boundaryConditionAtMergePoint,
-                      DCMPosFileName, DCMVelFileName,
+                      DCMPosFileName, DCMVelFileName, ZMPPosFileName,
                       mergePointsFileName,
                       lFootWeightFileName, rFootWeightFileName);
 
@@ -301,6 +314,7 @@ bool interpolationTest()
 
     // save data
     DCMPosFileName = "DCMPos2.txt";
+    ZMPPosFileName = "ZMPPos2.txt";
     DCMVelFileName = "DCMVel2.txt";
     mergePointsFileName = "mergePoints2.txt";
     lFootWeightFileName = "leftFootWeight2.txt";
@@ -309,8 +323,8 @@ bool interpolationTest()
     printSteps(unicycleGenerator.getLeftFootPrint()->getSteps(), unicycleGenerator.getRightFootPrint()->getSteps(),
                footstepsLFileName, footstepsRFileName);
 
-    printTrajectories(unicycleGenerator, newMergePoint, newMergePoint, boundaryConditionAtMergePoint,
-                      DCMPosFileName, DCMVelFileName,
+    printTrajectories(unicycleGenerator, newMergePoint, 0, boundaryConditionAtMergePoint,
+                      DCMPosFileName, DCMVelFileName, ZMPPosFileName,
                       mergePointsFileName,
                       lFootWeightFileName, rFootWeightFileName);
 
@@ -344,6 +358,7 @@ bool interpolationTest()
     heightFileName = "height3.txt";
     heightAccFileName = "heightAcc3.txt";
     DCMPosFileName = "DCMPos3.txt";
+    ZMPPosFileName = "ZMPPos3.txt";
     DCMVelFileName = "DCMVel3.txt";
     mergePointsFileName = "mergePoints3.txt";
     lFootWeightFileName = "leftFootWeight3.txt";
@@ -353,7 +368,7 @@ bool interpolationTest()
                footstepsLFileName, footstepsRFileName);
 
     printTrajectories(unicycleGenerator, newMergePoint, newMergePoint, boundaryConditionAtMergePoint,
-                      DCMPosFileName, DCMVelFileName,
+                      DCMPosFileName, DCMVelFileName, ZMPPosFileName,
                       mergePointsFileName,
                       lFootWeightFileName, rFootWeightFileName);
 


### PR DESCRIPTION
This PR:
1. Fix a bug related to the evaluation of the `omega` in the `DCMInterpolationTest`
2. Log the ZMP position in the `DCMInterpolationTest`
3. Introduce the `lastStepDCMOffset` parameter. This parameter can be used to change the final position of the DCM w.r.t. the position of the stance foot position.
In details if:
   1. `lastStepDCMOffset = 0` the DCM position is coincident with the stance foot ZMP position
   2. `lastStepDCMOffset = 0.5` the DCM position is in the middle of the two footprints
   3. `lastStepDCMOffset = 1` the DCM position is coincident with the next footprint position.
 
The following plot shows the result of the `DCMInterpolationTest` with different values of `lastStepDCMOffset`
![DCM](https://user-images.githubusercontent.com/16744101/66821471-c300cb80-ef42-11e9-9097-6b242b06b500.png)

cc @S-Dafarra 