### PR TITLE
Avoid the robot to step in place in case the minAngle is less than the feetYawDelta.

### DIFF
--- a/include/UnicycleFoot.h
+++ b/include/UnicycleFoot.h
@@ -25,6 +25,7 @@ class UnicycleFoot {
     iDynTree::Vector2 m_distance;
     bool m_distanceSet;
     double m_minimumStep;
+    double m_minimumAngle;
     double m_yawOffset;
     iDynTree::MatrixDynSize m_bufferR;
 
@@ -49,6 +50,8 @@ public:
     bool getLastStep(Step& lastStep) const;
 
     bool setTinyStepLength(double length);
+
+    bool setTinyStepAngle(double angle);
 
     bool isTinyStep(const UnicycleState &unicycleState); //given the position of the unicycle return true if the step would be tiny
 

--- a/include/UnicyclePlanner.h
+++ b/include/UnicyclePlanner.h
@@ -29,7 +29,7 @@ class UnicyclePlanner {
     std::shared_ptr<ControlledUnicycle> m_unicycle;
     iDynTree::optimalcontrol::integrators::RK4 m_integrator;
     UnicycleOptimization m_unicycleProblem;
-    double m_endTime, m_minTime, m_maxTime, m_nominalTime, m_dT, m_minAngle, m_nominalWidth, m_maxLength, m_minLength, m_maxAngle;
+    double m_initTime, m_endTime, m_minTime, m_maxTime, m_nominalTime, m_dT, m_minAngle, m_nominalWidth, m_maxLength, m_minLength, m_maxAngle;
     bool m_addTerminalStep, m_startLeft, m_resetStartingFoot, m_firstStep;
     FreeSpaceEllipseMethod m_freeSpaceMethod;
     double m_leftYawOffset, m_rightYawOffset;

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -241,6 +241,8 @@ bool UnicyclePlanner::addTerminalStep(const UnicycleState &lastUnicycleState)
     if (!(stanceFoot->getLastStep(prevStep)))
         return false;
 
+    double prevUnicycleAngle = stanceFoot->getUnicycleAngleFromStep(prevStep);
+
     iDynTree::Vector2 rPl, plannedPosition;
 
     if (!get_rPl(lastUnicycleState, rPl))
@@ -248,7 +250,7 @@ bool UnicyclePlanner::addTerminalStep(const UnicycleState &lastUnicycleState)
 
     swingFoot->getFootPositionFromUnicycle(lastUnicycleState, plannedPosition);
 
-    double deltaAngle = std::abs(lastUnicycleState.angle - prevStep.angle);
+    double deltaAngle = std::abs(lastUnicycleState.angle - prevUnicycleAngle);
     double deltaTime = m_endTime - prevStep.impactTime;
 
     bool isTinyForStance = stanceFoot->isTinyStep(lastUnicycleState);
@@ -641,6 +643,8 @@ bool UnicyclePlanner::computeNewSteps(std::shared_ptr< FootPrint > leftFoot, std
     if (!(stanceFoot->getLastStep(prevStep)))
         return false;
 
+    double prevUnicycleAngle = stanceFoot->getUnicycleAngleFromStep(prevStep);
+
     double t = initTime, tOptim = -1.0;
     pauseTime = t - prevStep.impactTime;
 
@@ -662,7 +666,7 @@ bool UnicyclePlanner::computeNewSteps(std::shared_ptr< FootPrint > leftFoot, std
             return false;
         }
 
-        deltaAngle = std::abs(prevStep.angle - unicycleState.angle);
+        deltaAngle = std::abs(prevUnicycleAngle - unicycleState.angle);
 
         if ((deltaTime >= m_minTime) && (t > (initTime + timeOffset))){ //The step is not too fast
             if (avoidPause || (!(swingFoot->isTinyStep(unicycleState)) || (deltaAngle > m_minAngle))){ //the step is not tiny


### PR DESCRIPTION
Fixes #42 

I have tested it in simulation. 

Instead of computing the difference in the orientation using directly the yaw of the foot, I consider the corresponding unicycle angle (after removing the delta).