### PR TITLE
Make GeneralSupportTrajectory::timeBelongsToDomain() method more robust with respect representation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(UnicyclePlanner
         LANGUAGES CXX
-        VERSION 0.5.1)
+        VERSION 0.5.2)
 
 # Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

--- a/include/DCMTrajectoryGeneratorHelper.h
+++ b/include/DCMTrajectoryGeneratorHelper.h
@@ -44,7 +44,7 @@ class GeneralSupportTrajectory
 
     std::pair<double, double> m_trajectoryDomain; /**< Time domain of the trajectory */
     double m_omega; /**< Time constant of the 3D-LIPM */
-
+    std::string m_type; /**< String representing the type of the trajectory. This is useful for debugging */
  public:
     /**
      * Constructor.
@@ -52,47 +52,60 @@ class GeneralSupportTrajectory
      * @param endTime is the end time of the trajectory;
      * @param omega time constant of the linear inverted pendulum.
      */
-    GeneralSupportTrajectory(const double &startTime, const double &endTime, const double& omega);
+    GeneralSupportTrajectory(const double &startTime, const double &endTime, const double& omega, const std::string& type);
 
     virtual ~GeneralSupportTrajectory();
+
+    /**
+     * Get the type of the trajectory. E.g., Single support, double support...
+     * @return the type of the trajectory
+     */
+    const std::string& getType() const;
 
     /**
      * Pure virtual method. It returns the position of the DCM
      * trajectory evaluated at time t.
      * @param t is the trajectory evaluation time;
      * @param DCMPosition cartesian position of the Diverget Component of Motion;
-     * @param checkDomainCondition flag used to check if the time belongs to the trajectory domain (default value true).
+     * @param checkDomainCondition flag used to check if the time belongs to the trajectory domain.
+     * @param domainTolerance tolerance applied to the check domain condition (default value 0.0).
      * @return true / false in case of success / failure.
      */
-    virtual bool getDCMPosition(const double &t, iDynTree::Vector2& DCMPosition, const bool &checkDomainCondition = true) = 0;
+    virtual bool getDCMPosition(const double &t, iDynTree::Vector2& DCMPosition, const bool &checkDomainCondition,
+                                const double &domainTolerance = 0.0) = 0;
 
     /**
      * Pure virtual method. It returns the velocity of the DCM
      * trajectory evaluated at time t.
      * @param t is the trajectory evaluation time;
      * @param DCMVelocity cartesian velocity of the Diverget Component of Motion;
-     * @param checkDomainCondition flag used to check if the time belongs to the trajectory domain (default value true).
+     * @param checkDomainCondition flag used to check if the time belongs to the trajectory domain.
+     * @param domainTolerance tolerance applied to the check domain condition (default value 0.0).
      * @return true / false in case of success / failure.
      */
-    virtual bool getDCMVelocity(const double &t, iDynTree::Vector2& DCMVelocity, const bool &checkDomainCondition = true) = 0;
+    virtual bool getDCMVelocity(const double &t, iDynTree::Vector2& DCMVelocity, const bool &checkDomainCondition,
+                                const double &domainTolerance = 0.0) = 0;
 
     /**
      * Pure virtual method. It returns the position of the ZMP
      * trajectory evaluated at time t.
      * @param t is the trajectory evaluation time;
      * @param ZMPPosition cartesian position of the Zero Moment Point;
-     * @param checkDomainCondition flag used to check if the time belongs to the trajectory domain (default value true).
+     * @param checkDomainCondition flag used to check if the time belongs to the trajectory domain.
+     * @param domainTolerance tolerance applied to the check domain condition (default value 0.0).
      * @return true / false in case of success / failure.
      */
-    virtual bool getZMPPosition(const double &t, iDynTree::Vector2& ZMPPosition, const bool &checkDomainCondition = true) = 0;
+    virtual bool getZMPPosition(const double &t, iDynTree::Vector2& ZMPPosition, const bool &checkDomainCondition,
+                                const double &domainTolerance = 0.0) = 0;
 
     /**
      * Return true if the time t belongs to the trajectory time
      * domain (i.e t belongs (startTime, endTime)).
      * @param t is the time.
-     * @return true if startTime <= t <=  endTime, false otherwise.
+     * @param tolerance positive number considered as a tolerance in the domain check (default value 0.0)
+     * @return true if startTime - tolerance <= t <=  endTime + tolerance, false otherwise.
      */
-    bool timeBelongsToDomain(const double &t);
+    bool timeBelongsToDomain(const double &t, const double& tolerance = 0.0);
 
     /**
      * Get the trajectory domain.

--- a/include/UnicycleGenerator.h
+++ b/include/UnicycleGenerator.h
@@ -55,6 +55,8 @@ public:
 
     bool setPauseConditions(double maxStepTime, double nominalStepTime);
 
+    void setPauseActive(bool isPauseActive);
+
     void disablePauseConditions();
 
 

--- a/src/UnicycleGenerator.cpp
+++ b/src/UnicycleGenerator.cpp
@@ -591,6 +591,7 @@ bool UnicycleGenerator::setPauseConditions(double maxStepTime, double nominalSte
     if (maxStepTime < 0){
         std::cerr << "[UnicycleGenerator::setPauseConditions] If the maxStepTime is negative, the robot won't pause in middle stance." << std::endl;
         m_pimpl->pauseActive = false;
+        return false;
     }
 
     m_pimpl->pauseActive = true;

--- a/src/UnicycleGenerator.cpp
+++ b/src/UnicycleGenerator.cpp
@@ -30,7 +30,7 @@ public:
     double switchPercentage = 0.5, dT = 0.01, endSwitch = 0.0, initTime = 0.0;
     double nominalSwitchTime = 1.0;
     double maxStepTime = 10.0, nominalStepTime = 2.0;
-    bool pauseActive = false;
+    bool pauseActive = true;
     double mergePointRatioBegin = 0.5;
     double mergePointRatioEnd = 0.5;
 
@@ -584,32 +584,31 @@ bool UnicycleGenerator::setTerminalHalfSwitchTime(double lastHalfSwitchTime)
     return true;
 }
 
+void UnicycleGenerator::setPauseActive(bool isPauseActive)
+{
+    m_pimpl->pauseActive = isPauseActive;
+}
+
 bool UnicycleGenerator::setPauseConditions(double maxStepTime, double nominalStepTime)
 {
     std::lock_guard<std::mutex> guard(m_pimpl->mutex);
 
     if (maxStepTime < 0){
         std::cerr << "[UnicycleGenerator::setPauseConditions] If the maxStepTime is negative, the robot won't pause in middle stance." << std::endl;
-        m_pimpl->pauseActive = false;
         return false;
     }
 
-    m_pimpl->pauseActive = true;
-    m_pimpl->maxStepTime = maxStepTime;
-
-    if (m_pimpl->pauseActive){
-        if (nominalStepTime <= 0){
-            std::cerr << "[UnicycleGenerator::setPauseConditions] The nominalStepTime is supposed to be positive." << std::endl;
-            m_pimpl->pauseActive = false;
-            return false;
-        }
-
-        if ((nominalStepTime) > maxStepTime){
-            std::cerr << "[UnicycleGenerator::setPauseConditions] The nominalSwitchTime cannot be greater than maxSwitchTime." << std::endl;
-            m_pimpl->pauseActive = false;
-            return false;
-        }
+    if (nominalStepTime <= 0){
+        std::cerr << "[UnicycleGenerator::setPauseConditions] The nominalStepTime is supposed to be positive." << std::endl;
+        return false;
     }
+
+    if ((nominalStepTime) > maxStepTime){
+        std::cerr << "[UnicycleGenerator::setPauseConditions] The nominalSwitchTime cannot be greater than maxSwitchTime." << std::endl;
+        return false;
+    }
+
+    m_pimpl->maxStepTime = maxStepTime;
     m_pimpl->nominalStepTime = nominalStepTime;
 
     return true;


### PR DESCRIPTION
I've tested it in simulation but we should try it on the robot before merging it.

Thanks to this PR the planner will not stop in case of a numeric representation error when calling `GeneralSupportTrajectory::timeBelongsToDomain()` 