### PR TITLE
New path interpolation method to sample footsteps from a path of poses/waypoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ build/*
 .DS_Store
 Thumbs.db
 .kdev4/*
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,8 @@ set(UCPLANNER_SOURCES src/ControlledUnicycle.cpp
                       src/DCMTrajectoryGenerator.cpp
                       src/DCMTrajectoryGeneratorHelper.cpp
                       src/FeetMinimumJerkGenerator.cpp
-                      src/FreeSpaceEllipse.cpp)
+                      src/FreeSpaceEllipse.cpp
+                      src/PosesPairInterpolator.cpp)
 
 set(UCPLANNER_HEADERS include/ControlledUnicycle.h
                       include/UnicycleBaseController.h
@@ -87,7 +88,8 @@ set(UCPLANNER_HEADERS include/ControlledUnicycle.h
                       include/DCMTrajectoryGenerator.h
                       include/DCMTrajectoryGeneratorHelper.h
                       include/FeetMinimumJerkGenerator.h
-                      include/FreeSpaceEllipse.h)
+                      include/FreeSpaceEllipse.h
+                      include/PosesPairInterpolator.h)
 
 add_library(UnicyclePlanner ${UCPLANNER_HEADERS} ${UCPLANNER_SOURCES})
 target_include_directories(UnicyclePlanner PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/include/PosesPairInterpolator.h
+++ b/include/PosesPairInterpolator.h
@@ -17,12 +17,6 @@
 class PosesPairInterpolator
 {
 private:
-
-    struct PoseStamped
-    {
-        UnicycleState pose;
-        double time;
-    };
     //Constraints on the motion given externally
     double m_maxVelocity;
     double m_maxLateralVelocity;
@@ -44,12 +38,19 @@ private:
     double m_linearETA;
     double m_angularETA;
     double m_dT;        //time increment of the interpolation
-    double m_time;      //quantity that gets incremented bt m_dT until maxTime or the next pose is reached
+    double m_time;      //quantity that gets incremented by m_dT until maxTime or the next pose is reached
+    double m_startTime; //time istant from which we start interpolating
+    double m_endTime;   //time horizon after which we end the computation
 public:
     PosesPairInterpolator(UnicycleState &startPose, UnicycleState &nextPose, 
-                          double &maxVelocity, double &maxLateralVelocity, double &maxAngVelocity, double &timeIncrement);
+                          const double &maxVelocity, const double &maxLateralVelocity, const double &maxAngVelocity, double &timeIncrement,
+                          double &startTime);
     ~PosesPairInterpolator();
-
+    struct PoseStamped
+    {
+        UnicycleState pose;
+        double time;
+    };
     bool computeMotionParameters();
     bool ETA_Computation();
     std::vector<PoseStamped> shimController();

--- a/include/PosesPairInterpolator.h
+++ b/include/PosesPairInterpolator.h
@@ -12,6 +12,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 #include "UnicycleFoot.h"
+#include <vector>
 
 //Computes the omnidirectional motion between two given poses
 class PosesPairInterpolator
@@ -42,9 +43,9 @@ private:
     double m_startTime; //time istant from which we start interpolating
     double m_endTime;   //time horizon after which we end the computation
 public:
-    PosesPairInterpolator(UnicycleState &startPose, UnicycleState &nextPose, 
-                          const double &maxVelocity, const double &maxLateralVelocity, const double &maxAngVelocity, double &timeIncrement,
-                          double &startTime);
+    PosesPairInterpolator(UnicycleState startPose, UnicycleState nextPose, 
+                          const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity, double timeIncrement,
+                          double startTime);
     ~PosesPairInterpolator();
     struct PoseStamped
     {
@@ -53,8 +54,8 @@ public:
     };
     bool computeMotionParameters();
     bool ETA_Computation();
-    std::vector<PoseStamped> shimController();
-    std::vector<PoseStamped> interpolate();
+    std::vector<PoseStamped> shimController(PosesPairInterpolator::PoseStamped startPose);
+    std::vector<PoseStamped> interpolate(PosesPairInterpolator::PoseStamped startPose);
 };
 
 

--- a/include/PosesPairInterpolator.h
+++ b/include/PosesPairInterpolator.h
@@ -14,47 +14,88 @@
 #include "UnicycleFoot.h"
 #include <vector>
 
-//Computes the omnidirectional motion between two given poses
+//Computes the omnidirectional motion between two given poses, at the maximum speed allowed
 class PosesPairInterpolator
 {
 private:
-    //Constraints on the motion given externally
-    double m_maxVelocity;
-    double m_maxLateralVelocity;
-    double m_maxAngVelocity;
+    //Constraints on the motion (computed externally)
+    double m_maxVelocity;               //max linear velocity
+    double m_maxLateralVelocity;        //max pure lateral speed allowed (y)
+    double m_maxAngVelocity;            //max angular velocity for yaw rotation
+
     //Poses between which the interpolation takes place
-    UnicycleState m_startPose;
-    UnicycleState m_nextPose;
+    UnicycleState m_startPose;          //start pose from which start interpolating
+    UnicycleState m_nextPose;           //end pose of interpolation
 
     // Motion parameters
-    iDynTree::Vector3 m_localVersors;   //(x, y, theta) direction sign components / versors
-    double m_cos_theta;
-    double m_sin_theta;
-    double m_distance;
-    double m_linearSpeed;
-    bool m_motionParamComputed{false};
+    iDynTree::Vector3 m_localVersors;   //(x, y, theta) direction sign components / versors from starting pose to next pose
+    double m_cos_theta;                 //cosine of the slope angle between the two poses
+    double m_sin_theta;                 //sine of the slope angle between the two poses
+    double m_distance;                  //cartesian distance between the two poses
+    double m_linearSpeed;               //constant translational speed from starting pose to next pose
+    bool m_motionParamComputed{false};  //flag that states if the motion parameters have already been computed
 
     //Time quantities
-    bool m_ETAsComputed{false};
-    double m_linearETA;
-    double m_angularETA;
-    double m_dT;        //time increment of the interpolation
-    double m_time;      //quantity that gets incremented by m_dT until maxTime or the next pose is reached
-    double m_startTime; //time istant from which we start interpolating
-    double m_endTime;   //time horizon after which we end the computation
+    bool m_ETAsComputed{false};     //flag that states if the time quantities have already been computed
+    double m_linearETA;             //time needed to reach the final X,Y pose
+    double m_angularETA;            //time needed to reach the final angular pose
+    double m_dT;                    //time increment of the interpolation
+    double m_time;                  //quantity that gets incremented by m_dT until time horizon or the next pose is reached
+    double m_startTime;             //time istant from which we start interpolating
+    double m_endTime;               //time horizon after which we end the computation
+
 public:
+
+    /**
+     * Default constructor of PosesPairInterpolator object
+     * @param startPose             starting pose from where starting to interpolate
+     * @param nextPose              final pose of the interpolation
+     * @param maxVelocity           max linear velocity allowed
+     * @param maxLateralVelocity    max pure lateral speed allowed (y)
+     * @param maxAngVelocity        max angular velocity for yaw rotation
+     * @param timeIncrement         time step of the interpolation
+     * @param startTime             time istant at the startPose
+     */
     PosesPairInterpolator(UnicycleState startPose, UnicycleState nextPose, 
                           const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity, double timeIncrement,
                           double startTime);
+
+    /**
+     * Default destructor
+     */
     ~PosesPairInterpolator();
+
+    //Struct containing the pose of the unicycle with its relative timestamp
     struct PoseStamped
     {
         UnicycleState pose;
         double time;
     };
+
+    /**
+     * Computes the Motion parameters of the motion between the two poses
+     * @return true in case of correct computation
+     */
     bool computeMotionParameters();
+
+    /**
+     * Computes the timings of the motion between the two poses
+     * @return true in case of correct computation
+     */
     bool ETA_Computation();
+
+    /**
+     * Rotation in place to compensate for a too big disalignment between the start and next pose
+     * @param startPose Pose where the robot starts rotating in place
+     * @return a vector of PoseStamped where X and Y state don't change, but only the angle
+     */
     std::vector<PoseStamped> shimController(PosesPairInterpolator::PoseStamped startPose);
+
+    /**
+     * Interpolation using a roto-traslating motion from the startPose to the next pose
+     * @param startPose Pose from where the robot starts roto-traslating
+     * @return a vector of PoseStamped up until the next pose
+     */
     std::vector<PoseStamped> interpolate(PosesPairInterpolator::PoseStamped startPose);
 };
 

--- a/include/PosesPairInterpolator.h
+++ b/include/PosesPairInterpolator.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Simone Micheletti
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#ifndef POSES_PAIR_INTERPOLATOR__H
+#define POSES_PAIR_INTERPOLATOR__H
+
+//Fix for compiling math constants
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include "UnicycleFoot.h"
+
+//Computes the omnidirectional motion between two given poses
+class PosesPairInterpolator
+{
+private:
+
+    struct PoseStamped
+    {
+        UnicycleState pose;
+        double time;
+    };
+    //Constraints on the motion given externally
+    double m_maxVelocity;
+    double m_maxLateralVelocity;
+    double m_maxAngVelocity;
+    //Poses between which the interpolation takes place
+    UnicycleState m_startPose;
+    UnicycleState m_nextPose;
+
+    // Motion parameters
+    iDynTree::Vector3 m_localVersors;   //(x, y, theta) direction sign components / versors
+    double m_cos_theta;
+    double m_sin_theta;
+    double m_distance;
+    double m_linearSpeed;
+    bool m_motionParamComputed{false};
+
+    //Time quantities
+    bool m_ETAsComputed{false};
+    double m_linearETA;
+    double m_angularETA;
+    double m_dT;        //time increment of the interpolation
+    double m_time;      //quantity that gets incremented bt m_dT until maxTime or the next pose is reached
+public:
+    PosesPairInterpolator(UnicycleState &startPose, UnicycleState &nextPose, 
+                          double &maxVelocity, double &maxLateralVelocity, double &maxAngVelocity, double &timeIncrement);
+    ~PosesPairInterpolator();
+
+    bool computeMotionParameters();
+    bool ETA_Computation();
+    std::vector<PoseStamped> shimController();
+    std::vector<PoseStamped> interpolate();
+};
+
+
+#endif // POSES_PAIR_INTERPOLATOR__H

--- a/include/UnicycleGenerator.h
+++ b/include/UnicycleGenerator.h
@@ -17,6 +17,11 @@
 #include <DCMTrajectoryGenerator.h>
 #include <memory>
 
+/**
+ * Enumerator for tracking the possible states of the navigation setup: manual -> classic original footstep planner for joystick use ; navigation -> path following based
+ */
+enum class NavigationSetup {ManualMode, NavigationMode, NotConfigured};
+
 class UnicycleGenerator {
     class UnicycleGeneratorImplementation;
    std::unique_ptr<UnicycleGeneratorImplementation> m_pimpl;
@@ -59,6 +64,9 @@ public:
 
     void disablePauseConditions();
 
+    bool setPlannerMode(NavigationSetup mode);
+
+    bool setNavigationPath(std::vector<UnicycleState> path);
 
     /**
      * Set the relative position of the merge point inside the double support phase.

--- a/include/UnicycleGenerator.h
+++ b/include/UnicycleGenerator.h
@@ -64,7 +64,7 @@ public:
 
     void disablePauseConditions();
 
-    bool setPlannerMode(NavigationSetup mode);
+    bool setPlannerMode(std::string mode);
 
     bool setNavigationPath(std::vector<UnicycleState> path);
 

--- a/include/UnicyclePlanner.h
+++ b/include/UnicyclePlanner.h
@@ -16,6 +16,7 @@
 #include "UnicycleOptimization.h"
 #include "UnicycleFoot.h"
 #include "FreeSpaceEllipse.h"
+#include "PosesPairInterpolator.h"
 #include <iDynTree/Integrators/ForwardEuler.h>
 #include <memory>
 #include <mutex>
@@ -50,12 +51,6 @@ class UnicyclePlanner {
 
     std::shared_ptr<UnicycleFoot> m_left, m_right;
 
-    struct PoseStamped
-    {
-        UnicycleState pose;
-        double time;
-    };
-
     //state
     bool m_swingLeft;
 
@@ -73,7 +68,7 @@ class UnicyclePlanner {
 
     bool checkConstraints(iDynTree::Vector2 rPl, double deltaAngle, double deltaTime, iDynTree::Vector2 newFootPosition, iDynTree::Vector2 prevStep);
 
-    std::vector<UnicyclePlanner::PoseStamped> interpolatePath(std::vector<UnicycleState> &navigationPath, const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity);
+    std::vector<PosesPairInterpolator::PoseStamped> interpolatePath(std::vector<UnicycleState> &navigationPath, const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity);
 
 public:
 

--- a/include/UnicyclePlanner.h
+++ b/include/UnicyclePlanner.h
@@ -7,7 +7,9 @@
 
 #ifndef UNICYCLEPLANNER_H
 #define UNICYCLEPLANNER_H
-
+//Fix for compiling math constants
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include "ControlledUnicycle.h"
 #include "PersonFollowingController.h"
 #include "UnicycleDirectController.h"
@@ -34,18 +36,25 @@ enum class UnicycleController
 class UnicyclePlanner {
     std::shared_ptr<PersonFollowingController> m_personFollowingController;
     std::shared_ptr<UnicycleDirectController> m_directController;
-    UnicycleController m_currentController;
+    //UnicycleController m_currentController; moved to public
     std::shared_ptr<ControlledUnicycle> m_unicycle;
     iDynTree::optimalcontrol::integrators::ForwardEuler m_integrator;
     UnicycleOptimization m_unicycleProblem;
-    double m_initTime, m_endTime, m_minTime, m_maxTime, m_nominalTime, m_dT, m_minAngle, m_nominalWidth, m_maxLength, m_maxLengthBackward, m_minLength, m_maxAngle;
+    double m_initTime, m_endTime, m_minTime, m_maxTime, m_nominalTime, m_dT, m_minAngle, m_nominalWidth, m_maxLength, m_maxLengthBackward, m_minLength, m_maxAngle, m_minWidth;
     bool m_addTerminalStep, m_startLeft, m_resetStartingFoot, m_firstStep;
     FreeSpaceEllipseMethod m_freeSpaceMethod;
     double m_leftYawOffset, m_rightYawOffset;
     double m_linearVelocityConservativeFactor, m_angularVelocityConservativeFactor;
     std::mutex m_mutex;
+    std::vector<UnicycleState> m_inputPath;
 
     std::shared_ptr<UnicycleFoot> m_left, m_right;
+
+    struct PoseStamped
+    {
+        UnicycleState pose;
+        double time;
+    };
 
     //state
     bool m_swingLeft;
@@ -62,7 +71,11 @@ class UnicyclePlanner {
 
     bool addTerminalStep(const UnicycleState &lastUnicycleState);
 
+    bool checkConstraints(iDynTree::Vector2 _rPl, double deltaAngle, double deltaTime, iDynTree::Vector2 newFootPosition, iDynTree::Vector2 prevStep);
+
 public:
+
+    UnicycleController m_currentController;
 
     UnicyclePlanner();
 
@@ -155,6 +168,10 @@ public:
     bool setInnerFreeSpaceEllipseOffsets(double semiMajorAxisOffset, double semiMinorAxisOffset);
 
     bool setUnicycleController(UnicycleController controller);
+
+    bool interpolateNewStepsFromPath(std::shared_ptr< FootPrint > leftFoot, std::shared_ptr< FootPrint > rightFoot, double initTime, double endTime);
+
+    bool setInputPath (std::vector<UnicycleState> input);
 };
 
 #endif // UNICYCLEPLANNER_H

--- a/include/UnicyclePlanner.h
+++ b/include/UnicyclePlanner.h
@@ -71,7 +71,7 @@ class UnicyclePlanner {
 
     bool addTerminalStep(const UnicycleState &lastUnicycleState);
 
-    bool checkConstraints(iDynTree::Vector2 _rPl, double deltaAngle, double deltaTime, iDynTree::Vector2 newFootPosition, iDynTree::Vector2 prevStep);
+    bool checkConstraints(iDynTree::Vector2 rPl, double deltaAngle, double deltaTime, iDynTree::Vector2 newFootPosition, iDynTree::Vector2 prevStep);
 
     std::vector<UnicyclePlanner::PoseStamped> interpolatePath(std::vector<UnicycleState> &navigationPath, const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity);
 

--- a/include/UnicyclePlanner.h
+++ b/include/UnicyclePlanner.h
@@ -73,6 +73,8 @@ class UnicyclePlanner {
 
     bool checkConstraints(iDynTree::Vector2 _rPl, double deltaAngle, double deltaTime, iDynTree::Vector2 newFootPosition, iDynTree::Vector2 prevStep);
 
+    std::vector<UnicyclePlanner::PoseStamped> interpolatePath(std::vector<UnicycleState> &navigationPath, const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity);
+
 public:
 
     UnicycleController m_currentController;

--- a/include/UnicyclePlanner.h
+++ b/include/UnicyclePlanner.h
@@ -44,7 +44,7 @@ class UnicyclePlanner {
     bool m_addTerminalStep, m_startLeft, m_resetStartingFoot, m_firstStep;
     FreeSpaceEllipseMethod m_freeSpaceMethod;
     double m_leftYawOffset, m_rightYawOffset;
-    double m_linearVelocityConservativeFactor, m_angularVelocityConservativeFactor;
+    double m_linearVelocityConservativeFactor, m_angularVelocityConservativeFactor, m_lateralVelocityConservaiveFactor;
     std::mutex m_mutex;
     std::vector<UnicycleState> m_inputPath;
 
@@ -174,6 +174,8 @@ public:
     bool interpolateNewStepsFromPath(std::shared_ptr< FootPrint > leftFoot, std::shared_ptr< FootPrint > rightFoot, double initTime, double endTime);
 
     bool setInputPath (std::vector<UnicycleState> input);
+
+    bool setLateralVelocityConservaiveFactor(double lateralVelocityConservaiveFactor);
 };
 
 #endif // UNICYCLEPLANNER_H

--- a/src/PosesPairInterpolator.cpp
+++ b/src/PosesPairInterpolator.cpp
@@ -7,6 +7,7 @@
 
 #include "PosesPairInterpolator.h"
 #include <iostream>
+#include <cmath>
 
 PosesPairInterpolator::PosesPairInterpolator(UnicycleState startPose, UnicycleState nextPose, 
                           const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity, double timeIncrement,

--- a/src/PosesPairInterpolator.cpp
+++ b/src/PosesPairInterpolator.cpp
@@ -6,11 +6,11 @@
  */
 
 #include "PosesPairInterpolator.h"
+#include <iostream>
 
-
-PosesPairInterpolator::PosesPairInterpolator(UnicycleState &startPose, UnicycleState &nextPose, 
-                          const double &maxVelocity, const double &maxLateralVelocity, const double &maxAngVelocity, double &timeIncrement,
-                          double &startTime)
+PosesPairInterpolator::PosesPairInterpolator(UnicycleState startPose, UnicycleState nextPose, 
+                          const double maxVelocity, const double maxLateralVelocity, const double maxAngVelocity, double timeIncrement,
+                          double startTime)
 {   
     m_maxVelocity = maxVelocity;
     m_maxLateralVelocity = maxLateralVelocity;
@@ -105,9 +105,10 @@ bool PosesPairInterpolator::ETA_Computation()
     return true;
 }
 
-std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimController()
+std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimController(PosesPairInterpolator::PoseStamped startPose)
 {
     std::vector<PoseStamped> interpolatedSegment;   //output of the interpolation of the ShimController
+    interpolatedSegment.push_back(startPose);
     //SHIM CONTROLLER. rotation BEFORE linear movement if I have a too big deltaPosesAngle.
     // The robot will rotate in-place until the extra agle will be compensated, then it will roto-translate to the next pose.
     if (m_angularETA > m_linearETA)     
@@ -138,6 +139,9 @@ std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimContr
             //save the pose
             PoseStamped ps {shimState, m_time};
             interpolatedSegment.push_back(ps);
+            std::cout << "Pose time: "<< interpolatedSegment.back().time << " X: " << interpolatedSegment.back().pose.position(0) 
+            << " Y: " << interpolatedSegment.back().pose.position(1) << " Angle: " << interpolatedSegment.back().pose.angle << std::endl;
+            
         }
         //now we have m_angularETA <= m_linearETA
         //so we add the missing time to m_linearETA and subtract it to m_angularETA
@@ -148,15 +152,18 @@ std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimContr
     return interpolatedSegment;
 }
 
-std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::interpolate()
+std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::interpolate(PosesPairInterpolator::PoseStamped startPose)
 {
+    std::cout << "PosesPairInterpolator::interpolate()" << std::endl;
     std::vector<PosesPairInterpolator::PoseStamped> interpolatedSegment;   //output
+    interpolatedSegment.push_back(startPose);
     double iterationEndTime = m_startTime + m_linearETA;    //add the time elapsed for all the previous poses in the path and the initial time (m_startTime)
 
     //interpolate between two path poses
     double sweptAngle = 0; //the cumulative angle which is being swept after each iter
     double missingAngle = m_angularETA * m_maxAngVelocity;    //angle missing to achieve the desired orientation of m_nextPose
-        
+    std::cout << "while loop" << std::endl;
+
     while (m_time < iterationEndTime)
     {
         //compute the next interpolated point
@@ -194,6 +201,8 @@ std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::interpola
         //save the pose
         PoseStamped ps {nextState, m_time};
         interpolatedSegment.push_back(ps);
+        std::cout << "Pose time: "<< interpolatedSegment.back().time << " X: " << interpolatedSegment.back().pose.position(0) 
+        << " Y: " << interpolatedSegment.back().pose.position(1) << " Angle: " << interpolatedSegment.back().pose.angle << std::endl;
     }
     return interpolatedSegment;
 }

--- a/src/PosesPairInterpolator.cpp
+++ b/src/PosesPairInterpolator.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2023 Fondazione Istituto Italiano di Tecnologia
+ * Authors: Simone Micheletti
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ *
+ */
+
+#include "PosesPairInterpolator.h"
+
+
+PosesPairInterpolator::PosesPairInterpolator(UnicycleState &startPose, UnicycleState &nextPose, 
+                          double &maxVelocity, double &maxLateralVelocity, double &maxAngVelocity, double &timeIncrement)
+{
+    m_maxVelocity = maxVelocity;
+    m_maxLateralVelocity = maxLateralVelocity;
+    m_maxAngVelocity = maxAngVelocity;
+    m_startPose = startPose;
+    m_nextPose = nextPose;
+    if (timeIncrement > 0)
+    {
+        m_dT = timeIncrement;
+    }
+    else
+    {
+        m_dT = 0.1; //default
+    }
+    
+    
+    
+}
+
+PosesPairInterpolator::~PosesPairInterpolator()
+{
+}
+
+bool PosesPairInterpolator::computeMotionParameters()
+{
+    if (m_motionParamComputed)
+    {
+        //
+        return true;
+    }
+    //Let's assume a linear uniform motion between two consecutive path poses at constant speed.
+    //we now calculate the future time istant of the next (i+1) pose in the path and the geometrical components
+    m_distance = std::sqrt(pow(m_nextPose.position(0) - m_startPose.position(0), 2) +
+                           pow(m_nextPose.position(1) - m_startPose.position(1), 2) 
+                           );
+    double slope = (m_nextPose.position(1) - m_startPose.position(1)) / 
+                   (m_nextPose.position(0) - m_startPose.position(0));
+    double slope_angle = atan(slope);
+    m_cos_theta = std::abs(cos(slope_angle));    
+    m_sin_theta = std::abs(sin(slope_angle)); 
+
+    //if both poses aligned to the path = 0, if both poses aligned but not with the path > 0, if both poses perpendicular to the path = 1
+    double proprotionFactor = (std::abs(slope_angle - m_nextPose.angle) + std::abs(slope_angle - m_startPose.angle))/ 2 / M_PI_2 ;
+    //linear speed module that moves from pose i to pose i+1
+    m_linearSpeed = std::abs(1 - proprotionFactor) * m_maxVelocity + proprotionFactor * m_maxLateralVelocity;
+
+    //calculate the direction, on the plane, of the two consecutive poses on its components (x,y,theta)
+    //(x, y, theta) direction sign components / versors
+    m_localVersors(0) = (m_nextPose.position(0) - m_startPose.position(0) >= 0) ? 1 : -1;
+    m_localVersors(1) = (m_nextPose.position(1) - m_startPose.position(1) >= 0) ? 1 : -1;
+    
+    //Angles vary between (-pi, pi]
+    double angleDifference = m_nextPose.angle - m_startPose.angle;
+    if (angleDifference > M_PI)
+    {
+        m_localVersors(2) = -1;
+    }
+    else if (angleDifference >=0 && angleDifference <= M_PI)
+    {
+        m_localVersors(2) = 1;
+    }
+    else if (angleDifference <0 && angleDifference >= -M_PI)
+    {
+        m_localVersors(2) = -1;
+    }
+    else    // angleDifference < -M_PI
+    {
+        m_localVersors(2) = 1;
+    }
+    m_motionParamComputed = true;
+    return true;
+}
+
+bool PosesPairInterpolator::ETA_Computation()
+{
+    //Initial checks
+    if (!m_motionParamComputed)
+    {
+        return false;
+    }
+    if (m_ETAsComputed)
+    {
+        return true;
+    }
+    //Computation
+    m_linearETA = m_distance / m_linearSpeed;  //Time required for moving from (x_i, y_i) to (x_i+1, y_i+1)
+    double deltaPosesAngle = std::abs(m_nextPose.angle - m_startPose.angle); //orientation difference between two consecutive path poses
+    if (deltaPosesAngle >= M_PI)    //take into account angle periodicity (-pi, pi]
+    {
+        deltaPosesAngle = std::abs(deltaPosesAngle - 2* M_PI);
+    }
+    m_angularETA = deltaPosesAngle / m_maxAngVelocity;   //Time required for moving from theta_i to theta_i+1
+
+    m_ETAsComputed = true;
+    return true;
+}
+
+std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimController()
+{
+    std::vector<PoseStamped> interpolatedSegment;   //output of the interpolation of the ShimController
+    //SHIM CONTROLLER. rotation BEFORE linear movement if I have a too big deltaPosesAngle.
+    // The robot will rotate in-place until the extra agle will be compensated, then it will roto-translate to the next pose.
+    if (m_angularETA > m_linearETA)     
+    {
+        double shimTime = 0;    //counter of how much time we take to complete the shim rotation
+        //compute the interpolation for the rotation of the unicycle on itself untill is aligned and add this time to the elapsedTimeLinear
+        //update also t for each dT passed
+        int missingIterations = std::ceil((m_angularETA - m_linearETA) / m_dT) ;    //round up by excess to calculate the number of iterations for fulling the time gap
+        UnicycleState shimState;
+        //Rotation in place -> X and Y don't change
+        shimState.position(0) = m_startPose.position(0);
+        shimState.position(1) = m_startPose.position(1);
+        for (size_t i = 1; i < missingIterations; i++)
+        {
+            m_time += m_dT;
+            shimTime += m_dT;
+            shimState.angle = interpolatedSegment.back().pose.angle + m_localVersors(2) * m_maxAngVelocity * m_dT;   
+            //deal with angle periodicity
+            if (shimState.angle > M_PI) //overshoot in the positive domain
+            {
+                shimState.angle -= 2*M_PI;
+            }
+            else if (shimState.angle < -M_PI)   //overshoot in the negative domain
+            {
+                shimState.angle += 2*M_PI;
+            }
+            
+            //save the pose
+            PoseStamped ps {shimState, m_time};
+            interpolatedSegment.push_back(ps);
+        }
+        //now we have elapsedTimeAngular <= elapsedTimeLinear
+        //so we add the missing time
+        m_linearETA += shimTime;
+    }
+         
+    return interpolatedSegment;
+}
+
+std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::interpolate()
+{
+    
+    return std::vector<PoseStamped>();
+}

--- a/src/PosesPairInterpolator.cpp
+++ b/src/PosesPairInterpolator.cpp
@@ -100,7 +100,6 @@ bool PosesPairInterpolator::ETA_Computation()
         deltaPosesAngle = std::abs(deltaPosesAngle - 2* M_PI);
     }
     m_angularETA = deltaPosesAngle / m_maxAngVelocity;   //Time required for moving from theta_i to theta_i+1
-    std::cout << "[ETA_Computation] m_linearETA: " << m_linearETA << " m_angularETA: " << m_angularETA << std::endl;
     m_ETAsComputed = true;
     return true;
 }
@@ -109,7 +108,7 @@ std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimContr
 {
     std::vector<PoseStamped> interpolatedSegment;   //output of the interpolation of the ShimController
     m_time = startPose.time;    //initialize the moment from which start the 
-    //SHIM CONTROLLER. rotation BEFORE linear movement if I have a too big deltaPosesAngle.
+    //SHIM CONTROLLER. rotation BEFORE the linear movement if I have a too big deltaPosesAngle.
     // The robot will rotate in-place until the extra agle will be compensated, then it will roto-translate to the next pose.
     if (m_angularETA > m_linearETA)     
     {
@@ -146,16 +145,12 @@ std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimContr
             
             //save the pose
             PoseStamped ps {shimState, m_time};
-            interpolatedSegment.push_back(ps);
-            std::cout << "Pose time: "<< interpolatedSegment.back().time << " X: " << interpolatedSegment.back().pose.position(0) 
-            << " Y: " << interpolatedSegment.back().pose.position(1) << " Angle: " << interpolatedSegment.back().pose.angle << std::endl;
-            
+            interpolatedSegment.push_back(ps);            
         }
         //now we have m_angularETA <= m_linearETA
         //so we add the missing time to m_linearETA and subtract it to m_angularETA
         m_linearETA += shimTime;
         m_angularETA -= shimTime;
-        std::cout << "[shimController] m_linearETA: " << m_linearETA << " m_angularETA: " << m_angularETA << std::endl;
     }
 
     return interpolatedSegment;
@@ -163,13 +158,11 @@ std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::shimContr
 
 std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::interpolate(PosesPairInterpolator::PoseStamped startPose)
 {
-    std::cout << "PosesPairInterpolator::interpolate()" << std::endl;
     std::vector<PosesPairInterpolator::PoseStamped> interpolatedSegment;   //output
     double iterationEndTime = m_startTime + m_linearETA;    //add the time elapsed for all the previous poses in the path and the initial time (m_startTime)
     //interpolate between two path poses
     double sweptAngle = 0; //the cumulative angle which is being swept after each iter
     double missingAngle = m_angularETA * m_maxAngVelocity;    //angle missing to achieve the desired orientation of m_nextPose
-    std::cout << "while loop" << std::endl;
 
     while (m_time < iterationEndTime)
     {
@@ -218,8 +211,6 @@ std::vector<PosesPairInterpolator::PoseStamped> PosesPairInterpolator::interpola
         //save the pose
         PoseStamped ps {nextState, m_time};
         interpolatedSegment.push_back(ps);
-        std::cout << "Pose time: "<< interpolatedSegment.back().time << " X: " << interpolatedSegment.back().pose.position(0) 
-        << " Y: " << interpolatedSegment.back().pose.position(1) << " Angle: " << interpolatedSegment.back().pose.angle << std::endl;
     }
     return interpolatedSegment;
 }

--- a/src/UnicycleGenerator.cpp
+++ b/src/UnicycleGenerator.cpp
@@ -842,9 +842,21 @@ std::shared_ptr<DCMTrajectoryGenerator> UnicycleGenerator::addDCMTrajectoryGener
     return m_pimpl->dcmTrajectoryGenerator;
 }
 
-bool UnicycleGenerator::setPlannerMode(NavigationSetup mode)
+bool UnicycleGenerator::setPlannerMode(std::string mode)
 {
-    m_pimpl->navigationConfig = mode;
+    if (mode == "navigation")
+    {
+        m_pimpl->navigationConfig = NavigationSetup::NavigationMode;
+    }
+    else if (mode == "manual")
+    {
+        m_pimpl->navigationConfig = NavigationSetup::ManualMode;
+    }
+    else
+    {
+        std::cerr << "[UnicycleGenerator::setNavigationPath] Unable to set planner mode: " << mode << std::endl;
+        return false;
+    }
     return true;
 }
 

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -1048,8 +1048,6 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
                                                   )
 {
     std::lock_guard<std::mutex> guard(m_mutex);
-    std::vector<UnicycleState> navigationPath = m_inputPath;    //input set externally fromm another method to m_inputPath
-    std::vector<UnicyclePlanner::PoseStamped> interpolatedPath;   //output of the integration
     
     // First consistency cheks
     if (!leftFoot || !rightFoot){
@@ -1072,6 +1070,9 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
         return false;
     }
 
+    std::vector<UnicycleState> navigationPath = m_inputPath;    //input set externally fromm another method to m_inputPath
+    std::vector<UnicyclePlanner::PoseStamped> interpolatedPath;   //output of the integration
+
     m_initTime = initTime;
     m_endTime = endTime;
 
@@ -1082,6 +1083,7 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
     double maxLateralVelocity = maxVelocity * 0.2;    //corrective factor equal to slowWhenSidewaysFactor - TODO: parameterize
     double maxAngVelocity = m_maxAngle/m_minTime * m_angularVelocityConservativeFactor;
 
+    // TODO are these saturations necessary?
     if (!m_personFollowingController->setSaturations(maxVelocity, maxAngVelocity))
         return false;
 
@@ -1142,162 +1144,7 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
     }
 
     //Interpolation of the given path
-    double prevTime = m_initTime;   //latest time istant of a pose in the path. It is initialized from the starting time, then will grow for each pose integrated
-    PoseStamped initialPS {navigationPath[0], prevTime};
-    interpolatedPath.push_back(initialPS);  //the first pose of the path
-
-    for (size_t i = 0; i < navigationPath.size() - 1; ++i)
-    {
-        //Let's assume a linear uniform motion between two consecutive path poses at constant speed.
-        //we now calculate the future time istant of the next (i+1) pose in the path and the geometrical components
-        double distance = std::sqrt(pow(navigationPath[i+1].position(0) - navigationPath[i].position(0), 2) +
-                                    pow(navigationPath[i+1].position(1) - navigationPath[i].position(1), 2) 
-                                    );
-        double slope = (navigationPath[i+1].position(1) - navigationPath[i].position(1)) / (navigationPath[i+1].position(0) - navigationPath[i].position(0));
-        double slope_angle = atan(slope);
-        double cos_theta = std::abs(cos(slope_angle));    
-        double sin_theta = std::abs(sin(slope_angle)); 
-
-        //if both poses aligned to the path = 0, if both poses aligned but not with the path > 0, if both poses perpendicular to the path = 1
-        double proprotionFactor = (std::abs(slope_angle - navigationPath[i+1].angle) + std::abs(slope_angle - navigationPath[i].angle))/ 2 / M_PI_2 ;
-        //linear speed module that moves from pose i to pose i+1
-        double linearSpeed = std::abs(1 - proprotionFactor) * maxVelocity + proprotionFactor * maxLateralVelocity;
-
-        //calculate the direction, on the plane, of the two consecutive poses on its components (x,y,theta)
-        iDynTree::Vector3 direction;   //(x, y, theta) direction sign components / versors
-        direction(0) = (navigationPath[i+1].position(0) - navigationPath[i].position(0) >= 0) ? 1 : -1;
-        direction(1) = (navigationPath[i+1].position(1) - navigationPath[i].position(1) >= 0) ? 1 : -1;
-        
-        //Angles vary between (-pi, pi]
-        double angleDifference = navigationPath[i+1].angle - navigationPath[i].angle;
-        if (angleDifference > M_PI)
-        {
-            direction(2) = -1;
-        }
-        else if (angleDifference >=0 && angleDifference <= M_PI)
-        {
-            direction(2) = 1;
-        }
-        else if (angleDifference <0 && angleDifference >= -M_PI)
-        {
-            direction(2) = -1;
-        }
-        else    // angleDifference < -M_PI
-        {
-            direction(2) = 1;
-        }
-
-        //Times computation. The linear and angular motions are considered indipendent from each other
-        double elapsedTimeLinear = distance / linearSpeed;  //Time required for moving from (x_i, y_i) to (x_i+1, y_i+1)
-        double deltaPosesAngle = std::abs(navigationPath[i+1].angle - navigationPath[i].angle); //orientation difference between two consecutive path poses
-        if (deltaPosesAngle >= M_PI)    //take into account angle periodicity (-pi, pi]
-        {
-            deltaPosesAngle = std::abs(deltaPosesAngle - 2* M_PI);
-        }
-
-        double elapsedTimeAngular = deltaPosesAngle / maxAngVelocity;   //Time required for moving from theta_i to theta_i+1
-        double iterationEndTime = 0;    // Time needed for reaching the next pose in the path. Initialized to 0
-
-        //SHIM CONTROLLER. rotation BEFORE linear movement if I have a too big deltaPosesAngle.
-        // The robot will rotate in-place until the extra agle will be compensated, then it will roto-translate to the goal pose.
-        if (elapsedTimeAngular > elapsedTimeLinear)     
-        {
-            //compute the interpolation for the rotation of the unicycle on itself untill is aligned and add this time to the elapsedTimeLinear
-            //update also t for each dT passed
-            int missingIterations = std::ceil((elapsedTimeAngular - elapsedTimeLinear) / m_dT) ;    //round up by excess to calculate the number of iterations for fulling the time gap
-            UnicycleState shimState;
-            //Rotation in place -> X and Y don't change
-            shimState.position(0) = navigationPath[i].position(0);
-            shimState.position(1) = navigationPath[i].position(1);
-            for (size_t i = 1; i < missingIterations; i++)
-            {
-                t += m_dT;
-                iterationEndTime += m_dT;
-                shimState.angle = interpolatedPath.back().pose.angle + direction(2) * maxAngVelocity * m_dT;   
-                //deal with angle periodicity
-                if (shimState.angle > M_PI) //overshoot in the positive domain
-                {
-                    shimState.angle -= 2*M_PI;
-                }
-                else if (shimState.angle < -M_PI)   //overshoot in the negative domain
-                {
-                    shimState.angle += 2*M_PI;
-                }
-                
-                //save the pose
-                PoseStamped ps {shimState, t};
-                interpolatedPath.push_back(ps);
-            }
-            //now we have elapsedTimeAngular <= elapsedTimeLinear
-            //so we add elapsedTimeLinear to the missing time
-            iterationEndTime += elapsedTimeLinear;
-        }
-        else
-        {
-            iterationEndTime = elapsedTimeLinear;   //we take the time from the linear motion
-        }
-        
-        iterationEndTime += prevTime;    //add the time elapsed for all the previous poses in the path and the initial time
-
-        //interpolate between two path poses
-        int iterationNum = 0;
-        double sweptAngle = 0; //the cumulative angle which is being swept after each iter
-        double missingAngle = 0;
-        if (elapsedTimeAngular >= elapsedTimeLinear)
-        {
-            missingAngle = std::ceil(elapsedTimeLinear / m_dT) * m_dT * maxAngVelocity;
-        }
-        else
-        {
-            missingAngle = elapsedTimeAngular * maxAngVelocity;
-        }
-        
-        while (t < iterationEndTime)
-        {
-            //compute the next interpolated point
-            t += m_dT;
-            ++iterationNum;
-            UnicycleState nextState;
-            //check if we overshoot the final pose -> then we clamp it
-            if (t >= iterationEndTime)
-            {
-                nextState.position(0) = navigationPath[i+1].position(0);
-                nextState.position(1) = navigationPath[i+1].position(1);
-                nextState.angle = navigationPath[i+1].angle;
-            }
-            else
-            {
-                //starting from the previous pose in the path, I add each passed increment on each component
-                nextState.position(0) = interpolatedPath.back().pose.position(0) + direction(0) * m_dT * (linearSpeed * cos_theta);    //the first part of the equation computes the number of iteration of dT passed untill this time istant.
-                                                                                                                                    //the second part is the x component of the maximum speed
-                nextState.position(1) = interpolatedPath.back().pose.position(1) + direction(1) * m_dT * (linearSpeed * sin_theta);
-                
-                double angleIncrement = m_dT * maxAngVelocity;
-                double next_angle = interpolatedPath.back().pose.angle + direction(2) * m_dT * maxAngVelocity;
-                sweptAngle += angleIncrement;
-                
-                if (sweptAngle >= missingAngle)
-                {
-                    nextState.angle = navigationPath[i+1].angle;
-                }
-                else
-                {
-                    nextState.angle = next_angle;
-                }
-            }
-            iterationNum = 0; //reset the counter for each couple of poses
-            
-            //save the pose
-            PoseStamped ps {nextState, t};
-            interpolatedPath.push_back(ps);
-        }
-        prevTime = t;   //keep track of the latest time istant
-        //check if we have passed the maximum time horizon
-        if (t >= m_endTime)
-        {
-            break;  //exit for loop
-        }
-    }
+    interpolatedPath = interpolatePath(navigationPath, maxVelocity, maxLateralVelocity, maxAngVelocity);
     //now we have everything on the interpolatedPath. Both time and poses for the whole time horizon
 
     //Reset variables
@@ -1515,4 +1362,171 @@ bool UnicyclePlanner::setInputPath (std::vector<UnicycleState> input)
 {
     m_inputPath = input;
     return true;
+}
+
+std::vector<UnicyclePlanner::PoseStamped> UnicyclePlanner::interpolatePath(std::vector<UnicycleState> &navigationPath, 
+                                        const double maxVelocity, 
+                                        const double maxLateralVelocity, 
+                                        const double maxAngVelocity)
+{
+    std::vector<UnicyclePlanner::PoseStamped> interpolatedPath;   //output of the interpolation
+    double t = m_initTime;          //time
+    double prevTime = m_initTime;   //latest time istant of a pose in the path. It is initialized from the starting time, then will grow for each pose integrated
+    PoseStamped initialPS {navigationPath[0], prevTime};
+    interpolatedPath.push_back(initialPS);  //the first pose of the path
+
+    for (size_t i = 0; i < navigationPath.size() - 1; ++i)
+    {
+        //Let's assume a linear uniform motion between two consecutive path poses at constant speed.
+        //we now calculate the future time istant of the next (i+1) pose in the path and the geometrical components
+        double distance = std::sqrt(pow(navigationPath[i+1].position(0) - navigationPath[i].position(0), 2) +
+                                    pow(navigationPath[i+1].position(1) - navigationPath[i].position(1), 2) 
+                                    );
+        double slope = (navigationPath[i+1].position(1) - navigationPath[i].position(1)) / 
+                        (navigationPath[i+1].position(0) - navigationPath[i].position(0));
+        double slope_angle = atan(slope);
+        double cos_theta = std::abs(cos(slope_angle));    
+        double sin_theta = std::abs(sin(slope_angle)); 
+
+        //if both poses aligned to the path = 0, if both poses aligned but not with the path > 0, if both poses perpendicular to the path = 1
+        double proprotionFactor = (std::abs(slope_angle - navigationPath[i+1].angle) + std::abs(slope_angle - navigationPath[i].angle))/ 2 / M_PI_2 ;
+        //linear speed module that moves from pose i to pose i+1
+        double linearSpeed = std::abs(1 - proprotionFactor) * maxVelocity + proprotionFactor * maxLateralVelocity;
+
+        //calculate the direction, on the plane, of the two consecutive poses on its components (x,y,theta)
+        iDynTree::Vector3 direction;   //(x, y, theta) direction sign components / versors
+        direction(0) = (navigationPath[i+1].position(0) - navigationPath[i].position(0) >= 0) ? 1 : -1;
+        direction(1) = (navigationPath[i+1].position(1) - navigationPath[i].position(1) >= 0) ? 1 : -1;
+        
+        //Angles vary between (-pi, pi]
+        double angleDifference = navigationPath[i+1].angle - navigationPath[i].angle;
+        if (angleDifference > M_PI)
+        {
+            direction(2) = -1;
+        }
+        else if (angleDifference >=0 && angleDifference <= M_PI)
+        {
+            direction(2) = 1;
+        }
+        else if (angleDifference <0 && angleDifference >= -M_PI)
+        {
+            direction(2) = -1;
+        }
+        else    // angleDifference < -M_PI
+        {
+            direction(2) = 1;
+        }
+
+        //Times computation. The linear and angular motions are considered indipendent from each other
+        double elapsedTimeLinear = distance / linearSpeed;  //Time required for moving from (x_i, y_i) to (x_i+1, y_i+1)
+        double deltaPosesAngle = std::abs(navigationPath[i+1].angle - navigationPath[i].angle); //orientation difference between two consecutive path poses
+        if (deltaPosesAngle >= M_PI)    //take into account angle periodicity (-pi, pi]
+        {
+            deltaPosesAngle = std::abs(deltaPosesAngle - 2* M_PI);
+        }
+
+        double elapsedTimeAngular = deltaPosesAngle / maxAngVelocity;   //Time required for moving from theta_i to theta_i+1
+        double iterationEndTime = 0;    // Time needed for reaching the next pose in the path. Initialized to 0
+
+        //SHIM CONTROLLER. rotation BEFORE linear movement if I have a too big deltaPosesAngle.
+        // The robot will rotate in-place until the extra agle will be compensated, then it will roto-translate to the goal pose.
+        if (elapsedTimeAngular > elapsedTimeLinear)     
+        {
+            //compute the interpolation for the rotation of the unicycle on itself untill is aligned and add this time to the elapsedTimeLinear
+            //update also t for each dT passed
+            int missingIterations = std::ceil((elapsedTimeAngular - elapsedTimeLinear) / m_dT) ;    //round up by excess to calculate the number of iterations for fulling the time gap
+            UnicycleState shimState;
+            //Rotation in place -> X and Y don't change
+            shimState.position(0) = navigationPath[i].position(0);
+            shimState.position(1) = navigationPath[i].position(1);
+            for (size_t i = 1; i < missingIterations; i++)
+            {
+                t += m_dT;
+                iterationEndTime += m_dT;
+                shimState.angle = interpolatedPath.back().pose.angle + direction(2) * maxAngVelocity * m_dT;   
+                //deal with angle periodicity
+                if (shimState.angle > M_PI) //overshoot in the positive domain
+                {
+                    shimState.angle -= 2*M_PI;
+                }
+                else if (shimState.angle < -M_PI)   //overshoot in the negative domain
+                {
+                    shimState.angle += 2*M_PI;
+                }
+                
+                //save the pose
+                PoseStamped ps {shimState, t};
+                interpolatedPath.push_back(ps);
+            }
+            //now we have elapsedTimeAngular <= elapsedTimeLinear
+            //so we add elapsedTimeLinear to the missing time
+            iterationEndTime += elapsedTimeLinear;
+        }
+        else
+        {
+            iterationEndTime = elapsedTimeLinear;   //we take the time from the linear motion
+        }
+        
+        iterationEndTime += prevTime;    //add the time elapsed for all the previous poses in the path and the initial time
+
+        //interpolate between two path poses
+        int iterationNum = 0;
+        double sweptAngle = 0; //the cumulative angle which is being swept after each iter
+        double missingAngle = 0;
+        if (elapsedTimeAngular >= elapsedTimeLinear)
+        {
+            missingAngle = std::ceil(elapsedTimeLinear / m_dT) * m_dT * maxAngVelocity;
+        }
+        else
+        {
+            missingAngle = elapsedTimeAngular * maxAngVelocity;
+        }
+        
+        while (t < iterationEndTime)
+        {
+            //compute the next interpolated point
+            t += m_dT;
+            ++iterationNum;
+            UnicycleState nextState;
+            //check if we overshoot the final pose -> then we clamp it
+            if (t >= iterationEndTime)
+            {
+                nextState.position(0) = navigationPath[i+1].position(0);
+                nextState.position(1) = navigationPath[i+1].position(1);
+                nextState.angle = navigationPath[i+1].angle;
+            }
+            else
+            {
+                //starting from the previous pose in the path, I add each passed increment on each component
+                nextState.position(0) = interpolatedPath.back().pose.position(0) + direction(0) * m_dT * (linearSpeed * cos_theta);    //the first part of the equation computes the number of iteration of dT passed untill this time istant.
+                                                                                                                                    //the second part is the x component of the maximum speed
+                nextState.position(1) = interpolatedPath.back().pose.position(1) + direction(1) * m_dT * (linearSpeed * sin_theta);
+                
+                double angleIncrement = m_dT * maxAngVelocity;
+                double next_angle = interpolatedPath.back().pose.angle + direction(2) * m_dT * maxAngVelocity;
+                sweptAngle += angleIncrement;
+                
+                if (sweptAngle >= missingAngle)
+                {
+                    nextState.angle = navigationPath[i+1].angle;
+                }
+                else
+                {
+                    nextState.angle = next_angle;
+                }
+            }
+            iterationNum = 0; //reset the counter for each couple of poses
+            
+            //save the pose
+            PoseStamped ps {nextState, t};
+            interpolatedPath.push_back(ps);
+        }
+        prevTime = t;   //keep track of the latest time istant
+        //check if we have passed the maximum time horizon
+        if (t >= m_endTime)
+        {
+            break;  //exit for loop
+        }
+    }
+    return interpolatedPath;
 }

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -390,6 +390,7 @@ UnicyclePlanner::UnicyclePlanner()
     ,m_swingLeft(true)
     , m_linearVelocityConservativeFactor(0.9)
     , m_angularVelocityConservativeFactor(0.7)
+    , m_lateralVelocityConservaiveFactor(0.2)
 {
     m_unicycle->setController(m_personFollowingController);
     m_integrator.setMaximumStepSize(0.01);
@@ -1041,6 +1042,22 @@ bool UnicyclePlanner::setUnicycleController(UnicycleController controller)
     return false;
 }
 
+bool UnicyclePlanner::setLateralVelocityConservaiveFactor(double lateralVelocityConservaiveFactor)
+{
+    std::lock_guard<std::mutex> guard(m_mutex);
+
+    if (lateralVelocityConservaiveFactor < 0.0 || lateralVelocityConservaiveFactor > 1.0)
+    {
+        std::cerr << " The parameter lateralVelocityConservaiveFactor is supposed to be between 0 and 1" << std::endl;
+        return false;
+    }
+    else
+    {
+        m_lateralVelocityConservaiveFactor = lateralVelocityConservaiveFactor;
+        return true;
+    }
+}
+
 bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > leftFoot, 
                                                   std::shared_ptr< FootPrint > rightFoot, 
                                                   double initTime, 
@@ -1080,7 +1097,7 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
     m_right.reset(new UnicycleFoot(rightFoot));
 
     double maxVelocity = std::sqrt(std::pow(m_maxLength,2) - std::pow(m_nominalWidth,2))/m_minTime * m_linearVelocityConservativeFactor;
-    double maxLateralVelocity = maxVelocity * 0.2;    //corrective factor equal to slowWhenSidewaysFactor - TODO: parameterize
+    double maxLateralVelocity = maxVelocity * m_lateralVelocityConservaiveFactor;    //corrective factor equal to slowWhenSidewaysFactor - TODO: parameterize 0.2
     double maxAngVelocity = m_maxAngle/m_minTime * m_angularVelocityConservativeFactor;
 
     // TODO are these saturations necessary?

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -945,23 +945,6 @@ bool UnicyclePlanner::computeNewSteps(std::shared_ptr< FootPrint > leftFoot, std
         }
 
     }
-    //Debug print
-    std::cout << "Passing from: numberOfStepsLeft = " << numberOfStepsLeft << " to " << leftFoot->numberOfSteps() << " and " << 
-    "Passing from: numberOfStepsRight = " << numberOfStepsRight << " to " << rightFoot->numberOfSteps() << std::endl;
-    std::cout << "LEFT STEPS" << std::endl;
-    for (auto step : leftFoot->getSteps()){
-        std::cerr << "Position "<< step.position.toString() << std::endl;
-        std::cerr << "Angle "<< iDynTree::rad2deg(step.angle) << std::endl;
-        std::cerr << "Time  "<< step.impactTime << std::endl;
-    }
-
-
-    std::cout << std::endl << "RIGHT STEPS" << std::endl;
-    for (auto step : rightFoot->getSteps()){
-        std::cerr << "Position "<< step.position.toString() << std::endl;
-        std::cerr << "Angle "<< iDynTree::rad2deg(step.angle) << std::endl;
-        std::cerr << "Time  "<< step.impactTime << std::endl;
-    }
     return true;
 }
 

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -1087,7 +1087,7 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
         return false;
     }
 
-    std::vector<UnicycleState> navigationPath = m_inputPath;    //input set externally fromm another method to m_inputPath
+    std::vector<UnicycleState> navigationPath = m_inputPath;    //input set externally from another method to m_inputPath
     std::vector<PosesPairInterpolator::PoseStamped> interpolatedPath;   //output of the integration
 
     m_initTime = initTime;
@@ -1148,7 +1148,8 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
     //The robot has to stay still at startup or when we have an invalid command
     if (navigationPath.size()<2)
     {
-        std::cerr <<"The navigation path has less than 2 poses (at least 2 points are needed) - Size: " << navigationPath.size() << " Staying still." <<std::endl;
+        std::cerr <<"The navigation path has less than 2 poses (at least 2 points are needed) - Size: " << 
+        navigationPath.size() << " Staying still." <<std::endl;
         
         UnicycleState zeroUnicycleState;
         //Get the unicycle state from the current step:
@@ -1159,18 +1160,14 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
         m_startLeft = true;
         return true;
     }
-    std::cout << "interpolatedPath = interpolatePath(navigationPath, maxVelocity, maxLateralVelocity, maxAngVelocity);" << std::endl;
     //Interpolation of the given path
     interpolatedPath = interpolatePath(navigationPath, maxVelocity, maxLateralVelocity, maxAngVelocity);
     //now we have everything on the interpolatedPath. Both time and poses for the whole time horizon
-    std::cout << "interpolatedPath.size() = " << interpolatedPath.size() << std::endl;
     //Reset variables
     t = m_initTime;
     tOptim = -1.0;
     //EVALUATION LOOP
     for (auto it = interpolatedPath.begin(); it != interpolatedPath.end(); ++it){
-        std::cout << "EVALUATION LOOP: Pose time: "<< it->time << " X: " << it->pose.position(0) 
-        << " Y: " << it->pose.position(1) << " Angle: " << it->pose.angle << std::endl;
         t = it->time;
         deltaTime = t - prevStep.impactTime;
 
@@ -1250,8 +1247,6 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
                     }
 
                 } else { //if ((deltaTime > m_maxTime) || (t == m_endTime)) //here I need to find the best solution
-                    std::cout << "EVALUATING Pose time: "<< interpolatedPath.back().time << " X: " << interpolatedPath.back().pose.position(0) 
-                    << " Y: " << interpolatedPath.back().pose.position(1) << " Angle: " << interpolatedPath.back().pose.angle << std::endl;
                     if(!get_rPl(unicycleState, rPl)){
                         std::cerr << "Error while retrieving the relative position from right to left." << std::endl;
                         return false;
@@ -1279,24 +1274,14 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
                             return false;
                         }
 
-                        std::cout<< "Evaluating best match: tOptim: " << tOptim << " minCost: " << minCost << 
-                        " optimalState X: " << unicycleState.position(0) << " optimalState Y: " << unicycleState.position(1) << 
-                        " optimalState Th: " << unicycleState.angle << std::endl;
-
                         if ((tOptim < 0) || (cost <= minCost)){ //no other feasible point has been found yet
                             tOptim = t;
                             minCost = cost;
                         }
                     }
-                    else
-                    {
-                        std::cout << "deltaTime > 0 : " << deltaTime << std::endl;
-                    }
-                    
                 }
             } else { //Arrive here if the step is tiny
                 pauseTime += m_dT;
-                std::cout << "TINY STEP - pauseTime: " << pauseTime << std::endl;
             }
         }
 
@@ -1347,21 +1332,6 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
 
     }
 
-    std::cout << "Passing from: numberOfStepsLeft = " << numberOfStepsLeft << " to " << leftFoot->numberOfSteps() << " and " << 
-    "Passing from: numberOfStepsRight = " << numberOfStepsRight << " to " << rightFoot->numberOfSteps() << std::endl;
-    std::cout << "LEFT STEPS" << std::endl;
-    for (auto step : leftFoot->getSteps()){
-        std::cerr << "Position "<< step.position.toString() << std::endl;
-        std::cerr << "Angle "<< iDynTree::rad2deg(step.angle) << std::endl;
-        std::cerr << "Time  "<< step.impactTime << std::endl;
-    }
-    std::cout << std::endl << "RIGHT STEPS" << std::endl;
-    for (auto step : rightFoot->getSteps()){
-        std::cerr << "Position "<< step.position.toString() << std::endl;
-        std::cerr << "Angle "<< iDynTree::rad2deg(step.angle) << std::endl;
-        std::cerr << "Time  "<< step.impactTime << std::endl;
-    }
-
     return true;
 }
 
@@ -1372,22 +1342,22 @@ bool UnicyclePlanner::checkConstraints(iDynTree::Vector2 rPl, double deltaAngle,
     double distance = (iDynTree::toEigen(newFootPosition) - iDynTree::toEigen(prevStepPosition)).norm();
 
     if (distance > m_maxLength){
-        std::cout <<"[ERROR] Distance constraint not satisfied: " << distance << std::endl;
+        //std::cout <<"[WARN] Distance constraint not satisfied: " << distance << std::endl;
         result = false;
     }
 
     if (deltaAngle > m_maxAngle){
-        std::cout <<"[ERROR] Angle constraint not satisfied: " << deltaAngle << std::endl;
+        //std::cout <<"[WARN] Angle constraint not satisfied: " << deltaAngle << std::endl;
         result = false;
     }
 
     if (deltaTime < m_minTime){
-        std::cout <<"[ERROR] Min time constraint not satisfied: " << deltaTime << std::endl;
+        //std::cout <<"[WARN] Min time constraint not satisfied: " << deltaTime << std::endl;
         result = false;
     }
 
     if (rPl(1) < m_minWidth){
-        std::cout <<"[ERROR] Width constraint not satisfied: " << rPl(1) << std::endl;
+        //std::cout <<"[WARN] Width constraint not satisfied: " << rPl(1) << std::endl;
         result = false;
     }
 
@@ -1403,174 +1373,6 @@ bool UnicyclePlanner::setInputPath (std::vector<UnicycleState> input)
     return true;
 }
 
-/*
-std::vector<UnicyclePlanner::PoseStamped> UnicyclePlanner::interpolatePath(std::vector<UnicycleState> &navigationPath, 
-                                        const double maxVelocity, 
-                                        const double maxLateralVelocity, 
-                                        const double maxAngVelocity)
-{
-    std::vector<UnicyclePlanner::PoseStamped> interpolatedPath;   //output of the interpolation
-    double t = m_initTime;          //time
-    double prevTime = m_initTime;   //latest time istant of a pose in the path. It is initialized from the starting time, then will grow for each pose integrated
-    PoseStamped initialPS {navigationPath[0], prevTime};
-    interpolatedPath.push_back(initialPS);  //the first pose of the path
-
-    for (size_t i = 0; i < navigationPath.size() - 1; ++i)
-    {
-        //Let's assume a linear uniform motion between two consecutive path poses at constant speed.
-        //we now calculate the future time istant of the next (i+1) pose in the path and the geometrical components
-        double distance = std::sqrt(pow(navigationPath[i+1].position(0) - navigationPath[i].position(0), 2) +
-                                    pow(navigationPath[i+1].position(1) - navigationPath[i].position(1), 2) 
-                                    );
-        double slope = (navigationPath[i+1].position(1) - navigationPath[i].position(1)) / 
-                        (navigationPath[i+1].position(0) - navigationPath[i].position(0));
-        double slope_angle = atan(slope);
-        double cos_theta = std::abs(cos(slope_angle));    
-        double sin_theta = std::abs(sin(slope_angle)); 
-
-        //if both poses aligned to the path = 0, if both poses aligned but not with the path > 0, if both poses perpendicular to the path = 1
-        double proprotionFactor = (std::abs(slope_angle - navigationPath[i+1].angle) + std::abs(slope_angle - navigationPath[i].angle))/ 2 / M_PI_2 ;
-        //linear speed module that moves from pose i to pose i+1
-        double linearSpeed = std::abs(1 - proprotionFactor) * maxVelocity + proprotionFactor * maxLateralVelocity;
-
-        //calculate the direction, on the plane, of the two consecutive poses on its components (x,y,theta)
-        iDynTree::Vector3 direction;   //(x, y, theta) direction sign components / versors
-        direction(0) = (navigationPath[i+1].position(0) - navigationPath[i].position(0) >= 0) ? 1 : -1;
-        direction(1) = (navigationPath[i+1].position(1) - navigationPath[i].position(1) >= 0) ? 1 : -1;
-        
-        //Angles vary between (-pi, pi]
-        double angleDifference = navigationPath[i+1].angle - navigationPath[i].angle;
-        if (angleDifference > M_PI)
-        {
-            direction(2) = -1;
-        }
-        else if (angleDifference >=0 && angleDifference <= M_PI)
-        {
-            direction(2) = 1;
-        }
-        else if (angleDifference <0 && angleDifference >= -M_PI)
-        {
-            direction(2) = -1;
-        }
-        else    // angleDifference < -M_PI
-        {
-            direction(2) = 1;
-        }
-
-        //Times computation. The linear and angular motions are considered indipendent from each other
-        double elapsedTimeLinear = distance / linearSpeed;  //Time required for moving from (x_i, y_i) to (x_i+1, y_i+1)
-        double deltaPosesAngle = std::abs(navigationPath[i+1].angle - navigationPath[i].angle); //orientation difference between two consecutive path poses
-        if (deltaPosesAngle >= M_PI)    //take into account angle periodicity (-pi, pi]
-        {
-            deltaPosesAngle = std::abs(deltaPosesAngle - 2* M_PI);
-        }
-
-        double elapsedTimeAngular = deltaPosesAngle / maxAngVelocity;   //Time required for moving from theta_i to theta_i+1
-        double iterationEndTime = 0;    // Time needed for reaching the next pose in the path. Initialized to 0
-
-        //SHIM CONTROLLER. rotation BEFORE linear movement if I have a too big deltaPosesAngle.
-        // The robot will rotate in-place until the extra agle will be compensated, then it will roto-translate to the goal pose.
-        if (elapsedTimeAngular > elapsedTimeLinear)     
-        {
-            //compute the interpolation for the rotation of the unicycle on itself untill is aligned and add this time to the elapsedTimeLinear
-            //update also t for each dT passed
-            int missingIterations = std::ceil((elapsedTimeAngular - elapsedTimeLinear) / m_dT) ;    //round up by excess to calculate the number of iterations for fulling the time gap
-            UnicycleState shimState;
-            //Rotation in place -> X and Y don't change
-            shimState.position(0) = navigationPath[i].position(0);
-            shimState.position(1) = navigationPath[i].position(1);
-            for (size_t i = 1; i < missingIterations; i++)
-            {
-                t += m_dT;
-                iterationEndTime += m_dT;
-                shimState.angle = interpolatedPath.back().pose.angle + direction(2) * maxAngVelocity * m_dT;   
-                //deal with angle periodicity
-                if (shimState.angle > M_PI) //overshoot in the positive domain
-                {
-                    shimState.angle -= 2*M_PI;
-                }
-                else if (shimState.angle < -M_PI)   //overshoot in the negative domain
-                {
-                    shimState.angle += 2*M_PI;
-                }
-                
-                //save the pose
-                PoseStamped ps {shimState, t};
-                interpolatedPath.push_back(ps);
-            }
-            //now we have elapsedTimeAngular <= elapsedTimeLinear
-            //so we add elapsedTimeLinear to the missing time
-            iterationEndTime += elapsedTimeLinear;
-        }
-        else
-        {
-            iterationEndTime = elapsedTimeLinear;   //we take the time from the linear motion
-        }
-        
-        iterationEndTime += prevTime;    //add the time elapsed for all the previous poses in the path and the initial time
-
-        //interpolate between two path poses
-        int iterationNum = 0;
-        double sweptAngle = 0; //the cumulative angle which is being swept after each iter
-        double missingAngle = 0;
-        if (elapsedTimeAngular >= elapsedTimeLinear)
-        {
-            missingAngle = std::ceil(elapsedTimeLinear / m_dT) * m_dT * maxAngVelocity;
-        }
-        else
-        {
-            missingAngle = elapsedTimeAngular * maxAngVelocity;
-        }
-        
-        while (t < iterationEndTime)
-        {
-            //compute the next interpolated point
-            t += m_dT;
-            ++iterationNum;
-            UnicycleState nextState;
-            //check if we overshoot the final pose -> then we clamp it
-            if (t >= iterationEndTime)
-            {
-                nextState.position(0) = navigationPath[i+1].position(0);
-                nextState.position(1) = navigationPath[i+1].position(1);
-                nextState.angle = navigationPath[i+1].angle;
-            }
-            else
-            {
-                //starting from the previous pose in the path, I add each passed increment on each component
-                nextState.position(0) = interpolatedPath.back().pose.position(0) + direction(0) * m_dT * (linearSpeed * cos_theta);    //the first part of the equation computes the number of iteration of dT passed untill this time istant.
-                                                                                                                                    //the second part is the x component of the maximum speed
-                nextState.position(1) = interpolatedPath.back().pose.position(1) + direction(1) * m_dT * (linearSpeed * sin_theta);
-                
-                double angleIncrement = m_dT * maxAngVelocity;
-                double next_angle = interpolatedPath.back().pose.angle + direction(2) * m_dT * maxAngVelocity;
-                sweptAngle += angleIncrement;
-                
-                if (sweptAngle >= missingAngle)
-                {
-                    nextState.angle = navigationPath[i+1].angle;
-                }
-                else
-                {
-                    nextState.angle = next_angle;
-                }
-            }
-            iterationNum = 0; //reset the counter for each couple of poses
-            
-            //save the pose
-            PoseStamped ps {nextState, t};
-            interpolatedPath.push_back(ps);
-        }
-        prevTime = t;   //keep track of the latest time istant
-        //check if we have passed the maximum time horizon
-        if (t >= m_endTime)
-        {
-            break;  //exit for loop
-        }
-    }
-    return interpolatedPath;
-}*/
-
 std::vector<PosesPairInterpolator::PoseStamped> UnicyclePlanner::interpolatePath(std::vector<UnicycleState> &navigationPath, 
                                         const double maxVelocity, 
                                         const double maxLateralVelocity, 
@@ -1583,31 +1385,37 @@ std::vector<PosesPairInterpolator::PoseStamped> UnicyclePlanner::interpolatePath
 
     for (size_t i = 0; i < navigationPath.size() - 1; ++i)
     {
-        std::cout << "pairInterpolator" << std::endl;
         PosesPairInterpolator pairInterpolator(navigationPath[i], navigationPath[i+1], maxVelocity, maxLateralVelocity, maxAngVelocity, m_dT, prevTime);
-        std::cout << "computeMotionParameters" << std::endl;
+
         if(!pairInterpolator.computeMotionParameters())
         {
+            std::cout << "[UnicyclePlanner::interpolatePath] unable to computeMotionParameters" << std::endl;
             return outputPath;
         }
-        std::cout << "ETA_Computation" << std::endl;
+
         if(!pairInterpolator.ETA_Computation())
         {
+            std::cout << "[UnicyclePlanner::interpolatePath] unable to ETA_Computation" << std::endl;
             return outputPath;
         }
-        std::cout << "shimController" << std::endl;
+
         std::vector<PosesPairInterpolator::PoseStamped> shimPart = pairInterpolator.shimController(outputPath.back());
         if(!shimPart.empty())
         {
-            //append the part to the path
             outputPath.insert(outputPath.end(), shimPart.begin(), shimPart.end());
         }
-        std::cout << "interpolationPart" << std::endl;
+
         std::vector<PosesPairInterpolator::PoseStamped> interpolationPart = pairInterpolator.interpolate(outputPath.back());
-        //append
-        outputPath.insert(outputPath.end(), interpolationPart.begin(), interpolationPart.end());
-        prevTime = interpolationPart.back().time;   //keep track of the latest time istant
-        std::cout << "prevTime: " << prevTime << std::endl;
+        if (interpolationPart.empty())
+        {
+            prevTime = outputPath.back().time;
+        }
+        else
+        {
+            outputPath.insert(outputPath.end(), interpolationPart.begin(), interpolationPart.end());
+            prevTime = interpolationPart.back().time;   //keep track of the latest time istant
+        }
+
         //check if we have passed the maximum time horizon
         if (prevTime >= m_endTime)
         {

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -1607,6 +1607,7 @@ std::vector<PosesPairInterpolator::PoseStamped> UnicyclePlanner::interpolatePath
         //append
         outputPath.insert(outputPath.end(), interpolationPart.begin(), interpolationPart.end());
         prevTime = interpolationPart.back().time;   //keep track of the latest time istant
+        std::cout << "prevTime: " << prevTime << std::endl;
         //check if we have passed the maximum time horizon
         if (prevTime >= m_endTime)
         {

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -1326,7 +1326,7 @@ bool UnicyclePlanner::interpolateNewStepsFromPath(std::shared_ptr< FootPrint > l
     return true;
 }
 
-bool UnicyclePlanner::checkConstraints(iDynTree::Vector2 _rPl, double deltaAngle, double deltaTime, iDynTree::Vector2 newFootPosition, iDynTree::Vector2 prevStepPosition){
+bool UnicyclePlanner::checkConstraints(iDynTree::Vector2 rPl, double deltaAngle, double deltaTime, iDynTree::Vector2 newFootPosition, iDynTree::Vector2 prevStepPosition){
 
     bool result = true;
 
@@ -1347,8 +1347,8 @@ bool UnicyclePlanner::checkConstraints(iDynTree::Vector2 _rPl, double deltaAngle
         result = false;
     }
 
-    if (_rPl(1) < m_minWidth){
-        std::cout <<"[ERROR] Width constraint not satisfied: " << _rPl(1) << std::endl;
+    if (rPl(1) < m_minWidth){
+        std::cout <<"[ERROR] Width constraint not satisfied: " << rPl(1) << std::endl;
         result = false;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 #          Giulio Romualdi
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.16)
 
 set (CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
PR for discussion of:

- Previous core methods/function have not been modified, all the new addiction is related to the navigation side and are not being used in the manual mode.
- Created a new module `PosesPairInterpolator` that interpolates a linear path from two poses, from a starting time instant for each time step (the concept is the same of a temporal integrator). This is similar to the `getIntegratorSolution(t, unicycleState)`
- This new module is used in a new method `interpolateNewStepsFromPath` in `UnicyclePlanner.cpp` that is analogue to `computeNewSteps` the logic structure is the same and keeps a lot of analogies.
- From the previous point, the Footstep evaluation and sampling is the same, but now a new function checks the constraints `checkConstraints` for simplicity.
- New struct for selecting the configuration mode of the planner `NavigationSetup`: the two main modes are Manual (default) and Navigation, a third and not used one is NotConfigured (if could be useful in the future) - in `UnicycleGenerator.cpp`
- Based on this config, in `UnicycleGenerator.cpp` each call to generate new footsteps now checks for the NavigationSetup AND the controller type. Calling `interpolateNewStepsFromPath` if in navigation mode and direct control, `ComputeNewSteps`  otherwise.
- The input path is set externally via `setInputPath` (for `interpolateNewStepsFromPath` only) in `UnicyclePlanner.cpp`
- `setLateralVelocityConservaiveFactor` in `UnicyclePlanner.cpp` allows to set a different conservative factor for `interpolateNewStepsFromPath` only