### PR TITLE
Reduction of DCM jumps when changing reference from an "almost" still configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ build/*
 Thumbs.db
 .kdev4/*
 .vscode/
+
+# Visual Studio
+.vs/*
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(UnicyclePlanner
         LANGUAGES CXX
-        VERSION 0.7.0)
+        VERSION 0.8.0)
 
 # Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

--- a/include/DCMTrajectoryGenerator.h
+++ b/include/DCMTrajectoryGenerator.h
@@ -81,6 +81,13 @@ public:
     bool setAlpha(const double &alpha);
 
     /**
+     * Set the percentage of the last double support where the robot is completely still.
+     * @param alpha is the percentage of the last double support where the robot is completely still.
+     * @return true / false in case of success / failure.
+     */
+    bool setStillnessPercentage(const double& stillnessPercentage);
+
+    /**
      * Set the last step DCM offset
      * @param lastStepDCMOffset Number from 0 to 1 used to indicate the position of the DCM w.r.t. the last ZMP position.
      * If it is 0.5 the final DCM will be in the middle of the two footsteps;

--- a/include/DCMTrajectoryGenerator.h
+++ b/include/DCMTrajectoryGenerator.h
@@ -57,6 +57,9 @@ public:
 
     bool setDCMInitialState(const DCMInitialState &initialState);
 
+
+    const DCMInitialState & getDCMInitialState() const;
+
     /**
      * Set the time constant of the 3D-LIPM.
      * @param omega is the time constant of the 3D-LIPM.

--- a/include/DCMTrajectoryGeneratorHelper.h
+++ b/include/DCMTrajectoryGeneratorHelper.h
@@ -126,6 +126,7 @@ class DCMTrajectoryGeneratorHelper
     double m_dT; /**< Planner period. */
     double m_omega; /**< Time constant of the 3D-LIPM. */
     double m_alpha; /**< alpha is the parameter between zero and one for distributing the DS duration to SS phase. */
+    double m_stillnessPercentage; /**< Percentage of the last double support where the robot is completely still. */
     iDynTree::Vector2 m_leftZMPDelta; /**< Vector containing the desired left ZMP delta. */
     iDynTree::Vector2 m_rightZMPDelta; /**< Vector containing the desired left ZMP delta. */
     FirstDCMTrajectoryMode m_firstDCMTrajectoryMode{FirstDCMTrajectoryMode::ThirdOrderPoly}; /**< Mode of the first DS DCM trajectory */
@@ -245,6 +246,13 @@ class DCMTrajectoryGeneratorHelper
      * @return true / false in case of success / failure.
      */
     bool setAlpha(const double &alpha);
+
+    /**
+     * Set the percentage of the last double support where the robot is completely still.
+     * @param alpha is the percentage of the last double support where the robot is completely still.
+     * @return true / false in case of success / failure.
+     */
+    bool setStillnessPercentage(const double& stillnessPercentage);
 
     /**
      * Set the period of the Trajectory generator planner.

--- a/src/DCMTrajectoryGenerator.cpp
+++ b/src/DCMTrajectoryGenerator.cpp
@@ -128,6 +128,14 @@ bool DCMTrajectoryGenerator::setDCMInitialState(const DCMInitialState &initialSt
     return true;
 }
 
+const DCMInitialState & DCMTrajectoryGenerator::getDCMInitialState() const
+{
+
+    std::lock_guard<std::mutex> guard(m_pimpl->mutex);
+
+    return m_pimpl->initialState;
+}
+
 bool DCMTrajectoryGenerator::setOmega(const double &omega)
 {
     std::lock_guard<std::mutex> guard(m_pimpl->mutex);

--- a/src/DCMTrajectoryGenerator.cpp
+++ b/src/DCMTrajectoryGenerator.cpp
@@ -157,6 +157,13 @@ bool DCMTrajectoryGenerator::setAlpha(const double &alpha)
     return m_pimpl->helper.setAlpha(alpha);
 }
 
+bool DCMTrajectoryGenerator::setStillnessPercentage(const double& stillnessPercentage)
+{
+    std::lock_guard<std::mutex> guard(m_pimpl->mutex);
+
+    return m_pimpl->helper.setStillnessPercentage(stillnessPercentage);
+}
+
 bool DCMTrajectoryGenerator::setLastStepDCMOffsetPercentage(const double &lastStepDCMOffset)
 {
     std::lock_guard<std::mutex> guard(m_pimpl->mutex);

--- a/src/UnicycleGenerator.cpp
+++ b/src/UnicycleGenerator.cpp
@@ -195,8 +195,7 @@ public:
         stance->insert(stance->end(), switchSamples, StepPhase::SwitchOut);
         phaseShift.push_back(phaseShift.back() + switchSamples);
 
-        for (size_t m = phaseShift.back() - switchSamples; m < phaseShift.back(); ++m)
-            mergePoints.push_back(m);
+        mergePoints.push_back(phaseShift.back() - 1); //merge on the last
 
         lFootPhases->shrink_to_fit();
         rFootPhases->shrink_to_fit();

--- a/src/UnicycleGenerator.cpp
+++ b/src/UnicycleGenerator.cpp
@@ -14,6 +14,8 @@
 #include <cstddef>
 #include <mutex>
 
+#include <iDynTree/Core/EigenHelpers.h>
+
 typedef StepList::const_iterator StepsIndex;
 
 class UnicycleGenerator::UnicycleGeneratorImplementation {
@@ -486,6 +488,19 @@ bool UnicycleGenerator::reGenerate(double initTime, double dT, double endTime, b
         m_pimpl->leftFootPrint->getLastStep(previousL);
         m_pimpl->rightFootPrint->getLastStep(previousR);
 
+
+	if (m_pimpl->dcmTrajectoryGenerator != nullptr
+	    && iDynTree::toEigen(m_pimpl->dcmTrajectoryGenerator->getDCMInitialState().initialVelocity).norm() < 1e-5)
+	{
+	    double max = std::max(previousL.impactTime, previousR.impactTime);
+	    previousL.impactTime = previousR.impactTime = max;
+
+	    m_pimpl->leftFootPrint->clearSteps();
+	    m_pimpl->rightFootPrint->clearSteps();
+	    m_pimpl->leftFootPrint->addStep(previousL);
+	    m_pimpl->rightFootPrint->addStep(previousR);	    
+	}
+       	
         std::shared_ptr<FootPrint> toBeCorrected = correctLeft ? m_pimpl->leftFootPrint : m_pimpl->rightFootPrint;
 
         correctedStep = correctLeft ? previousL : previousR;

--- a/src/UnicyclePlanner.cpp
+++ b/src/UnicyclePlanner.cpp
@@ -42,7 +42,7 @@ bool UnicyclePlanner::getInitialStateFromFeet(double initTime)
             unicycleState.position.zero();
             unicycleState.angle = 0.0;
         }
-        
+
 
         m_left->addStepFromUnicycle(unicycleState, initTime);
         m_right->addStepFromUnicycle(unicycleState, initTime);
@@ -439,7 +439,7 @@ bool UnicyclePlanner::setSlowWhenTurnGain(double slowWhenTurnGain)
     std::lock_guard<std::mutex> guard(m_mutex);
 
     return m_personFollowingController->setSlowWhenTurnGain(slowWhenTurnGain) &&
-            m_directController->setSlowWhenTurnGain(slowWhenTurnGain) && 
+            m_directController->setSlowWhenTurnGain(slowWhenTurnGain) &&
             m_navigationController->setSlowWhenTurnGain(slowWhenTurnGain);
 }
 
@@ -456,7 +456,7 @@ bool UnicyclePlanner::setSlowWhenSidewaysFactor(double slowWhenSidewaysFactor)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    return m_personFollowingController->setSlowWhenSidewaysFactor(slowWhenSidewaysFactor) && 
+    return m_personFollowingController->setSlowWhenSidewaysFactor(slowWhenSidewaysFactor) &&
             m_directController->setSlowWhenSidewaysFactor(slowWhenSidewaysFactor) &&
             m_navigationController->setSlowWhenSidewaysFactor(slowWhenSidewaysFactor);
 }
@@ -554,7 +554,7 @@ bool UnicyclePlanner::setMaximumIntegratorStepSize(double dT)
         std::cerr << "[UnicyclePlanner::setMaximumIntegratorStepSize] unable to set the TimeStep to the navigation controller" << std::endl;
         return false;
     }
-    
+
     return m_integrator.setMaximumStepSize(dT);
 }
 


### PR DESCRIPTION
This PR mitigates the jumps on the robot when changing references with the robot not completely still