### PR TITLE
Bump minimum required CMake version to 3.10 and bump version to 0.8.1 to fix compatibility with CMake >= 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 project(UnicyclePlanner
         LANGUAGES CXX
-        VERSION 0.8.0)
+        VERSION 0.8.1)
 
 # Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,11 +2,6 @@
 # Authors: Stefano Dafarra
 #          Giulio Romualdi
 # CopyPolicy: Released under the terms of the BSD-3-Clause license, see LICENSE
-cmake_minimum_required(VERSION 3.1)
-
-set (CMAKE_CXX_STANDARD 11)
-
-project(UnicyclePlannerTest)
 
 # UnicycleTest
 add_executable(UnicycleTest UnicycleTest.cpp)


### PR DESCRIPTION
Fix for https://github.com/robotology/robotology-superbuild/issues/1831 . 

CMake 3.10 was released in 2017, and is the version used in Ubuntu apt packages since Ubuntu 18.04 (see https://repology.org/project/cmake/versions), I think it is perfectly fine to require it.